### PR TITLE
fix(auth): report a revoked session as revoked, in the tool and in status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ name; see [`CONTEXT.md`](CONTEXT.md) for the rest of the evidence ladder.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A revoked session was reported as no session at all.** A 401 from the refresh endpoint appended
+  the no-token-at-all sentence — "No Stockbit session stored. Run `stockbit-auth login` first." — to
+  a failure whose whole meaning is that a token *is* stored and Stockbit refused it. `status`, which
+  reads the very journal that failure writes, said it correctly at the same moment: "present and
+  unexpired, but Stockbit rejected it". Two reports of one state, disagreeing on whether the user
+  had ever logged in, and the tool's version is the one an agent relays — sending the user to fix a
+  login that was never the problem. Each token domain now carries a separate `rejected` message
+  naming what actually happened; `missing` stays for the genuinely-absent case.
+
+- **A refused website session was still reported as healthy.** `webSessionHealth` judged the refresh
+  token's expiry and nothing else, so a revoked session — unexpired payload, every byte unchanged —
+  read as `stored, ~6.0d left` while the browser opened a chart, received Stockbit's empty shell and
+  threw. The chart path is the only place that can observe that refusal, and the observation died
+  with the process that made it, so the next `status` went on quoting the expiry of a credential the
+  browser had just proved dead. The health journal already answered exactly this question for the
+  three token slots; its key now covers the website session too, the refusal is recorded where it is
+  detected, and a recorded rejection outranks the clock. The fingerprint check comes with it, so a
+  rejection about a session the user has since replaced stays quiet.
+
 ## [1.2.2] — 2026-08-29
 
 ### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,27 @@ is not enough.
 CI runs typecheck, test, build, smoke, check:pack and a `docs/TOOLS.md` freshness check on Ubuntu,
 macOS and Windows against Node 22 and 24.
 
+### `npx stockbit-mcp` does not work *inside this checkout*
+
+Every `npx` invocation in this project's own docs — `.mcp.json`, and the `npx -y -p stockbit-mcp
+stockbit-auth login` that `status` prints — fails here and only here:
+
+```
+$ npx -y stockbit-mcp@^1
+sh: stockbit-mcp: command not found
+```
+
+npx reads the `package.json` in the working directory, finds a package *named* `stockbit-mcp` whose
+version already satisfies the spec, concludes it is installed, and execs the bin from
+`./node_modules/.bin/` — where it is absent, because a package does not link its own bins. It is not
+a packaging fault and installers never hit it: the same command works from any other directory.
+
+In the checkout, run the local build instead — `node dist/bin/stockbit-mcp.js`, or `npm start` /
+`npm run dev:mcp`. The same goes for the auth CLI: `node dist/bin/stockbit-auth.js login`.
+
+`.mcp.json` must keep pointing at npm regardless (`test/distribution.test.ts` asserts it): it is the
+Claude Code plugin's config, and a plugin checkout has no `dist/` to point at.
+
 ## The tests are offline, and must stay that way
 
 `fetch` is stubbed. Nothing in the suite touches the network, a real Keychain, a real browser or a

--- a/src/auth/health.ts
+++ b/src/auth/health.ts
@@ -56,7 +56,18 @@ export interface SlotHealth {
   lastFailure?: RefreshRecord;
 }
 
-export type HealthJournal = Partial<Record<StoreSlot, SlotHealth>>;
+/**
+ * What this journal can hold an entry for.
+ *
+ * A superset of `StoreSlot`, and deliberately: the website session is NOT a token slot — it lives in
+ * `websession.enc` and is never served by `getStore` — but it fails the same way, is judged the same
+ * way, and until it was recorded here the browser could prove it dead while `status` went on
+ * reporting "~6.0d left". The journal already answered "what happened the last time this credential
+ * was used" for every other credential; the website session was the one that had no way to say.
+ */
+export type HealthKey = StoreSlot | "websession";
+
+export type HealthJournal = Partial<Record<HealthKey, SlotHealth>>;
 
 /**
  * What `status` can say about a slot without spending anything.
@@ -95,7 +106,7 @@ function write(journal: HealthJournal): void {
 }
 
 /** Record that a refresh with `token` succeeded. Never throws. */
-export function recordRefreshOk(slot: StoreSlot, token: string): void {
+export function recordRefreshOk(slot: HealthKey, token: string): void {
   const journal = readHealthJournal();
   const entry = journal[slot] ?? {};
   entry.lastOk = { at: new Date().toISOString(), token: tokenFingerprint(token) };
@@ -111,7 +122,7 @@ export function recordRefreshOk(slot: StoreSlot, token: string): void {
  * a user pasting it into a public issue.
  */
 export function recordRefreshFailure(
-  slot: StoreSlot,
+  slot: HealthKey,
   token: string,
   status: number | undefined,
   reason: string,
@@ -129,7 +140,7 @@ export function recordRefreshFailure(
 }
 
 /** Forget everything recorded for a slot, or for all of them. Called by `logout`. */
-export function clearSessionHealth(slot?: StoreSlot): void {
+export function clearSessionHealth(slot?: HealthKey): void {
   if (!slot) {
     try {
       if (existsSync(sessionHealthPath())) writeFileAtomic(sessionHealthPath(), Buffer.alloc(0));
@@ -158,7 +169,7 @@ export function clearSessionHealth(slot?: StoreSlot): void {
  *     ordinary state on a fresh install, and it is reported as ignorance rather than as health.
  */
 export function slotHealthState(
-  slot: StoreSlot,
+  slot: HealthKey,
   token: string | null,
   expired: boolean,
   journal: HealthJournal = readHealthJournal(),
@@ -180,7 +191,7 @@ export function slotHealthState(
 }
 
 /** The recorded event that explains a slot's state, so `status` can quote a time. */
-export function lastEventFor(slot: StoreSlot, journal: HealthJournal = readHealthJournal()): RefreshRecord | null {
+export function lastEventFor(slot: HealthKey, journal: HealthJournal = readHealthJournal()): RefreshRecord | null {
   const entry = journal[slot];
   if (!entry) return null;
   const { lastOk, lastFailure } = entry;

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -114,6 +114,14 @@ interface DomainSpec {
   presentation: "header" | "body" | "query";
   /** What to tell a user who has no token for this domain. Names the command that gets one. */
   missing: string;
+  /**
+   * What to tell a user whose token IS stored and was REJECTED. A different state from `missing`,
+   * and it used to borrow that sentence: a revoked session answered "No Stockbit session stored",
+   * which contradicts `status` — that reads the same journal this failure writes and says "present
+   * and unexpired, but Stockbit rejected it". Telling a user they never logged in, when they did,
+   * sends them to fix the wrong thing.
+   */
+  rejected: string;
 }
 
 const DOMAINS: Record<TokenDomain, DomainSpec> = {
@@ -122,6 +130,9 @@ const DOMAINS: Record<TokenDomain, DomainSpec> = {
     refreshRoute: "loginRefresh",
     presentation: "header",
     missing: "No Stockbit session stored. Run `stockbit-auth login` first.",
+    rejected:
+      "The stored session was revoked, or superseded by another login — it is present and " +
+      "unexpired, so only Stockbit can see this. Log in again: `stockbit-auth login`.",
   },
   securities: {
     slot: "securities",
@@ -130,12 +141,19 @@ const DOMAINS: Record<TokenDomain, DomainSpec> = {
     missing:
       "Trading session not set up — run `stockbit-auth trading-login`. " +
       "It asks for your 6-digit trading PIN once; the PIN is never stored and never reaches this server.",
+    rejected:
+      "The stored trading session was revoked or has ended — run `stockbit-auth trading-login` " +
+      "again. It asks for your 6-digit trading PIN once; the PIN is never stored and never reaches " +
+      "this server.",
   },
   eipo: {
     slot: "eipo",
     refreshRoute: "eipoRefreshToken",
     presentation: "query",
     missing: "No e-IPO session. It is minted automatically from your Stockbit login — run `stockbit-auth login`.",
+    rejected:
+      "The stored e-IPO session was rejected. It is minted from your Stockbit login, so logging in " +
+      "again re-mints it: `stockbit-auth login`.",
   },
 };
 
@@ -583,7 +601,7 @@ async function refreshOnce(domain: TokenDomain, attempt = 0, locked = false): Pr
     throw new StockbitError(
       "auth",
       res.status === 401
-        ? `Refresh failed (HTTP 401) — the stored ${domain} token is no longer valid. ${spec.missing}`
+        ? `Refresh failed (HTTP 401) — the stored ${domain} token is no longer valid. ${spec.rejected}`
         : `Refresh failed (HTTP ${res.status}) for the ${domain} session`,
       { status: res.status },
     );

--- a/src/auth/websession.ts
+++ b/src/auth/websession.ts
@@ -39,6 +39,7 @@ import { hostname, userInfo } from "node:os";
 import { join } from "node:path";
 import { fileDir, writeFileAtomic } from "./store.js";
 import { extractRefresh, looksLikeJwt } from "./capture.js";
+import { lastEventFor, recordRefreshFailure, slotHealthState } from "./health.js";
 import type { CDP } from "./cdp.js";
 
 /** One cookie, in the shape `Storage.setCookies` will take straight back. */
@@ -543,6 +544,43 @@ function readSessionCredential(session: WebSession): WebSessionCredential | null
 }
 
 /**
+ * The website session's REFRESH token — for FINGERPRINTING, never for presenting.
+ *
+ * The health journal identifies a credential by a digest of it, so that a recorded rejection can be
+ * told from one about a token the user has since replaced. The refresh token is the right one to
+ * fingerprint here for the same reason it is the one `webSessionHealth` judges: it is the session's
+ * real identity, and it survives the 24h access token turning over underneath it.
+ */
+function readSessionRefreshToken(session: WebSession): string | null {
+  const parsed = parseCredentialCookie(session);
+  const state = (parsed?.payload as { state?: Record<string, unknown> } | null)?.state;
+  if (!state || typeof state !== "object") return null;
+  return slotToken(state.refresh);
+}
+
+/**
+ * Write down that the browser proved this website session stale.
+ *
+ * Called from the one place that can know it — the chart opened, Stockbit returned its shell, and
+ * the shell rendered nothing. Before this existed that discovery died with the process, so the next
+ * `status` went on quoting the refresh token's expiry and reporting a dead session as healthy.
+ *
+ * Best-effort and silent by design: it runs on the way to throwing an error the user is about to
+ * read, and a diagnostics file that cannot be written must not replace that error with its own.
+ */
+export function recordWebSessionRejection(reason: string): void {
+  try {
+    const session = loadWebSession();
+    if (!session) return;
+    const token = readSessionRefreshToken(session);
+    if (!token) return;
+    recordRefreshFailure("websession", token, 401, reason);
+  } catch {
+    /* best effort — see above */
+  }
+}
+
+/**
  * The ACCESS token the browser is currently holding.
  *
  * Separate from `readSessionCredential`, which returns expiries only and must stay safe to log.
@@ -577,9 +615,18 @@ export interface WebSessionHealth {
   likelyValid: boolean;
   /** PROVABLY dead: the refresh token's expiry was read and has passed. Only this blocks a launch. */
   expired: boolean;
+  /**
+   * PROVABLY refused: the browser opened a chart and Stockbit served a shell that rendered nothing,
+   * which is what it does when this session is stale. Recorded in the health journal, so it survives
+   * the process that discovered it and costs nothing to read back.
+   *
+   * Distinct from `expired`: an unexpired credential can still be revoked, and no byte of the
+   * payload changes when it is. This is the only field that can tell that story.
+   */
+  rejected: boolean;
   hint: string;
   /** What the verdict rests on. `unknown` means nothing is claimed either way. */
-  basis: "refresh-token" | "unknown" | "absent";
+  basis: "refresh-token" | "unknown" | "absent" | "rejected";
   /** Hours until the ~7d refresh token dies — the session's real deadline. Null if unreadable. */
   refreshHoursLeft: number | null;
   refreshExpiresAt: string | null;
@@ -620,6 +667,7 @@ export function webSessionHealth(): WebSessionHealth {
     ageHours: null,
     likelyValid: false,
     expired: false,
+    rejected: false,
     refreshHoursLeft: null,
     refreshExpiresAt: null,
     accessHoursLeft: null,
@@ -649,6 +697,26 @@ export function webSessionHealth(): WebSessionHealth {
     refreshHoursLeft,
     accessHoursLeft,
   };
+
+  // Rejected outranks every clock-based verdict below, because it is the only one backed by an
+  // actual answer from Stockbit. An expiry that is still in the future says nothing about a session
+  // that has been revoked — and that combination, "~6.0d left" printed over a session the browser
+  // had already proved dead, is exactly what this rung exists to stop.
+  const refreshToken = readSessionRefreshToken(session);
+  if (refreshToken && slotHealthState("websession", refreshToken, false) === "failing") {
+    const at = lastEventFor("websession")?.at;
+    return {
+      ...shared,
+      basis: "rejected" as const,
+      rejected: true,
+      hint:
+        "The stored website session was REFUSED by Stockbit" +
+        (at ? ` at ${new Date(at).toLocaleTimeString()}` : "") +
+        " — a chart loaded and rendered nothing, which is what a stale session looks like. Its " +
+        "refresh token has not expired, so no expiry check can see this. Run `stockbit-auth login`. " +
+        "The REST tools use a separate credential and may still be fine.",
+    };
+  }
 
   // Unknown. Say so, and do not stand in the way — the chart's own logged-out detection is a better
   // answer than a guess made from here.

--- a/src/chartbit/session.ts
+++ b/src/chartbit/session.ts
@@ -36,7 +36,7 @@ import type { ChildProcess } from "node:child_process";
 import { CDP } from "../auth/cdp.js";
 import { launchDebuggableBrowser } from "../auth/launch.js";
 import { defaultProfileDir } from "../auth/login.js";
-import { seedWebSession, webSessionHealth } from "../auth/websession.js";
+import { recordWebSessionRejection, seedWebSession, webSessionHealth } from "../auth/websession.js";
 import { pinnedBrowserExists, readBrowserProfile } from "../auth/browserprofile.js";
 import { defaultBrowserPath, familyForPath } from "../auth/browsers.js";
 import { fileDir } from "../auth/store.js";
@@ -432,7 +432,14 @@ export class ChartbitSession {
       // The document arrived and rendered nothing. That is not "not signed in" and not "still
       // loading" — it is an app whose own API calls are being refused, which on Stockbit means the
       // browser profile's session has gone stale even though the CLI's API token is fine. Those are
-      // two different credentials and only one of them is being reported by `status`.
+      // two different credentials.
+      //
+      // Write it down BEFORE building the message, so the hint quoted below is the new verdict
+      // rather than the stale "alive, ~Nd left" it would otherwise still be reading off an expiry.
+      // This is the only place in the codebase that can observe a website session being refused;
+      // until it recorded that, the observation died with the process and `status` kept reporting a
+      // session the browser had just proved dead as healthy.
+      recordWebSessionRejection(`chart shell rendered nothing for ${symbol}`);
       throw new StockbitError(
         "auth",
         `The chart page for ${symbol} loaded but rendered nothing: the markup is there and its height ` +

--- a/src/status.ts
+++ b/src/status.ts
@@ -510,6 +510,11 @@ export async function collectStatus(options: CollectStatusOptions = {}): Promise
     // dead while every slot above is perfectly healthy. That combination is what made the original
     // failure so hard to read.
     checks.push({ name: "website session", status: "warn", detail: web.hint });
+  } else if (web.rejected) {
+    // `fail`, not `warn`: this is not a deadline approaching, it is a credential Stockbit has
+    // already refused. It reads the same as the token slots' `failing` rung, and for the same
+    // reason — both are recorded observations rather than inferences from an expiry.
+    checks.push({ name: "website session", status: "fail", detail: web.hint });
   }
   checks.push(runningCodeCheck());
 
@@ -756,6 +761,11 @@ function describeWebSession(web: WebSessionHealth): string {
 
   const age = web.ageHours === null ? "age unknown" : `captured ${web.ageHours.toFixed(1)}h ago`;
 
+  if (web.rejected) {
+    // Ahead of every clock-based line below, for the same reason the health rung is: this one is
+    // the only verdict Stockbit actually gave. Reporting "~6.0d left" over it was the bug.
+    return "REJECTED by Stockbit — a chart rendered nothing; run `stockbit-auth login`";
+  }
   if (web.basis === "unknown") {
     // Unknown is not dead. Demanding a login here is the same pessimism that cost a daily one.
     return `stored, ${age} — validity unreadable, the chart will settle it`;

--- a/test/reflock.test.ts
+++ b/test/reflock.test.ts
@@ -507,6 +507,19 @@ test("a 401 with nothing newer in the web session still fails, and says how to r
         assert.ok(err instanceof StockbitError);
         assert.equal(err.status, 401);
         assert.match(err.message, /stockbit-auth login/);
+
+        // A REJECTED session is not a MISSING one, and the message must not confuse them. This
+        // sentence used to end "No Stockbit session stored. Run `stockbit-auth login` first." —
+        // borrowed wholesale from the no-token-at-all case — while `status`, reading the journal
+        // this very failure writes, correctly said "present and unexpired, but Stockbit rejected
+        // it". Two reports of one state, disagreeing on whether the user had ever logged in. An
+        // agent relaying the tool's version sends them to fix a login that is not the problem.
+        assert.doesNotMatch(
+          err.message,
+          /No Stockbit session stored/,
+          "a stored-but-revoked token must not be reported as no token at all",
+        );
+        assert.match(err.message, /revoked, or superseded/, "say what actually happened to it");
         return true;
       },
     );

--- a/test/websession.test.ts
+++ b/test/websession.test.ts
@@ -33,9 +33,11 @@ import {
   webSessionLaunchBlocker,
   readSessionAccessToken,
   alignStoredCredential,
+  recordWebSessionRejection,
   type StoredCookie,
   type WebSession,
 } from "../src/auth/websession.ts";
+import { clearSessionHealth, readHealthJournal } from "../src/auth/health.ts";
 
 after(() => rmSync(STORE, { recursive: true, force: true }));
 
@@ -457,4 +459,76 @@ test("allowOlder is the explicit escape hatch, so nothing is permanently stuck",
 
   const left = webSessionHealth().accessHoursLeft;
   assert.ok(left !== null && left < 2, "an explicit older write must land");
+});
+
+/* ------------------------- a session Stockbit has actually refused ------------------------- */
+
+/**
+ * The fourth credential could be PROVED dead and still be reported as healthy.
+ *
+ * `webSessionHealth` judged the refresh token's expiry and nothing else, so a revoked session —
+ * unexpired payload, every byte unchanged — kept reading as "alive, ~6.0d left" while the browser
+ * opened a chart, got Stockbit's empty shell, and threw. The observation died with the process that
+ * made it. The token slots had a journal recording exactly this; the website session was the one
+ * credential with no way to say what had happened to it.
+ *
+ * These pin the two halves that make the record worth trusting: a rejection is believed over the
+ * clock, and a rejection about a session the user has since replaced is not.
+ */
+test("a REFUSED website session outranks the days left on its refresh token", () => {
+  clearWebSession();
+  clearSessionHealth("websession");
+  saveWebSession(session([pairCookie(HOUR, 6 * DAY)]));
+  assert.equal(webSessionHealth().likelyValid, true, "precondition: the clock says this is fine");
+
+  recordWebSessionRejection("chart shell rendered nothing for BBRI");
+
+  const health = webSessionHealth();
+  assert.equal(health.rejected, true);
+  assert.equal(health.basis, "rejected");
+  assert.equal(health.likelyValid, false, "a refused session is not 'probably alive'");
+  assert.ok(
+    health.refreshHoursLeft !== null && health.refreshHoursLeft > (5 * DAY) / HOUR,
+    "the refresh token is still unexpired — which is the whole point",
+  );
+  assert.match(health.hint, /REFUSED/);
+  assert.match(health.hint, /stockbit-auth login/, "the hint must name the way out");
+});
+
+test("a rejection recorded against a REPLACED session says nothing about the new one", () => {
+  // The fingerprint check: what stops the journal shouting about a credential the user has already
+  // replaced by logging in again.
+  clearWebSession();
+  clearSessionHealth("websession");
+  saveWebSession(session([pairCookie(HOUR, 6 * DAY)]));
+  recordWebSessionRejection("stale");
+  assert.equal(webSessionHealth().rejected, true, "precondition");
+
+  saveWebSession(session([pairCookie(2 * HOUR, 7 * DAY)]));
+
+  const health = webSessionHealth();
+  assert.equal(health.rejected, false, "the recorded failure was about a token that is gone");
+  assert.equal(health.likelyValid, true);
+});
+
+test("recording a rejection with nothing stored is a no-op, not a throw", () => {
+  // It runs on the way to throwing an error the user is about to read, and must never replace it.
+  clearWebSession();
+  clearSessionHealth("websession");
+  assert.doesNotThrow(() => recordWebSessionRejection("nothing stored"));
+  assert.equal(webSessionHealth().present, false);
+});
+
+test("the rejection record carries a fingerprint and no part of any token", () => {
+  clearWebSession();
+  clearSessionHealth("websession");
+  saveWebSession(session([pairCookie(HOUR, 6 * DAY)]));
+  const stored = readCredentialStorage(loadWebSession()!) as { refresh?: { token?: string } } | null;
+  recordWebSessionRejection("stale");
+
+  const serialised = JSON.stringify(readHealthJournal().websession);
+  assert.ok(serialised.includes("sha256:"), "the record identifies the credential by digest");
+  assert.doesNotMatch(serialised, /eyJ/, "nothing JWT-shaped may reach the journal");
+  const token = stored?.refresh?.token;
+  if (token) assert.ok(!serialised.includes(token.slice(0, 24)), "no substring of the token either");
 });


### PR DESCRIPTION
Two defects in how this server reports a session it can no longer use. Both were found by driving the MCP surface against a live account whose market-data token had been revoked mid-session, which is the state that makes them visible.

## A revoked session was reported as no session at all

A 401 from the refresh endpoint appended the no-token-at-all sentence to a failure whose whole meaning is the opposite:

```
Refresh failed (HTTP 401) — the stored main token is no longer valid.
No Stockbit session stored. Run `stockbit-auth login` first.
```

A session *was* stored. Stockbit had revoked it. `status` — reading the very journal that failure writes — said so correctly at the same moment: *"present and unexpired, but Stockbit rejected it ... revoked, or superseded by another login"*. Two reports of one state, disagreeing on whether the user had ever logged in, and the tool's version is the one an agent relays. It sends the user to fix a login that was never the problem.

Each token domain now carries a separate `rejected` message naming what actually happened. `missing` stays for the genuinely-absent case.

## A refused website session was still reported as healthy

`webSessionHealth` judged the refresh token's expiry and nothing else. So a revoked website session — unexpired payload, every byte unchanged — read as `stored, ~6.0d left` while the browser opened a chart, received Stockbit's empty shell and threw.

The chart path is the only place that can observe that refusal, and the observation died with the process that made it. The next `status` went on quoting the expiry of a credential the browser had just proved dead.

The health journal already answered exactly this question for the three token slots. Its key now covers the website session too, the refusal is recorded where it is detected, and a recorded rejection outranks the clock. The fingerprint check comes with it, so a rejection about a session the user has since replaced stays quiet.

Before and after, against the same genuinely stale session:

```
before:  Website session  stored, captured 23.2h ago, ~6.0d left
after:   Website session  REJECTED by Stockbit — a chart rendered nothing; run `stockbit-auth login`
         [fail] website session: ... Its refresh token has not expired, so no expiry
         check can see this. Run `stockbit-auth login`. The REST tools use a separate
         credential and may still be fine.
```

## Also here

`CONTRIBUTING.md` gains a note on a trap that costs an afternoon: **`npx stockbit-mcp` cannot run this package from inside its own checkout.** npx reads the working directory's `package.json`, finds a package named `stockbit-mcp` whose version satisfies the spec, concludes it is installed, and execs the bin from `./node_modules/.bin/` — where it is absent, because a package does not link its own bins. Every npx line in this project's docs fails here and only here, including the one `status` prints as its remedy. It presents as an opaque `Connection closed` when the plugin's `.mcp.json` is used from this repo.

`.mcp.json` itself is deliberately unchanged: it is the plugin's config, a plugin checkout has no `dist/`, and `test/distribution.test.ts` is right to pin it to npm. The note documents the local-build workaround instead.

## Checklist

- `typecheck`, `test`, `build`, `smoke`, `check:pack` all pass — **1578 tests, 0 fail** (up from 1574).
- `docs/TOOLS.md` regenerated and unchanged; no tool was touched.
- No non-GET route added, so no ADR.
- No fixtures touched; no evidence declarations changed.
- `CHANGELOG.md` entry under `## [Unreleased]`.

## What is not settled

The gate ran on macOS / Node 24 only — CI's Ubuntu, Windows and Node 22 legs are the point of this PR.

The new rejection path is verified live in the direction that fires: it was recorded and surfaced against a genuinely stale session. It is **not** verified live in the direction that clears — that a fresh login makes the rejection stop being reported. The fingerprint test covers that offline (`a rejection recorded against a REPLACED session says nothing about the new one`), but the live path needs a working token. Worth a look before merge.

Separately and not addressed here: five `projected` tools answer HTTP 404 `Unrecognized Command` — `underwriters`, `eipo_list`, `eipo_price_groups`, `eipo_rdn_balance`, `eipo_order_preview`. With no live session it cannot be told whether the routes are wrong or the e-IPO token could never be minted, and settling an evidence claim takes a live call rather than an edit.