### PR TITLE
chore(mailmap): one person, one name

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,20 @@
-# One line per identity that should display under the maintainer's canonical name.
+# One line per identity that should display under its owner's canonical name.
 #
-# The 2026-08-25 history rewrite removed the other two identities this file used to need
-# (a GitHub web-UI commit and an old local-hostname author), so only the name normalisation
-# is left. Garit32's identity is deliberately untouched — they are a separate contributor.
+# This file only affects what GIT shows — `git log`, `git shortlog`, `git blame`. GitHub does not
+# read it: its contributor graph and auto-generated release notes come from the commit author
+# EMAIL and which account has that email verified. So consolidating an identity here and
+# consolidating it on GitHub are two separate jobs, and this file can only do the first.
+#
+# The 2026-08-25 history rewrite removed two identities this file used to need (a GitHub web-UI
+# commit and an old local-hostname author), leaving the name normalisation below.
+
 Marvel Harisson <im.marvel.harisson@gmail.com> INo-xious <im.marvel.harisson@gmail.com>
+
+# Darren Wang, confirmed 2026-08-31 to be one person behind three git identities. `xthom2001` is a
+# secondary GitHub account (created 2026-04-26, no repositories); `Garit32` is the main one and the
+# canonical form below is its noreply address, so the real address stays out of the public log.
+#
+# The earlier note here called Garit32 "a separate contributor". That was wrong, and it is exactly
+# the kind of thing a mailmap should record once rather than have each reader re-derive.
+Darren Wang <100551715+Garit32@users.noreply.github.com> Darren <xthom2001@gmail.com>
+Darren Wang <100551715+Garit32@users.noreply.github.com> Garit32 <valorantgovol1@gmail.com>


### PR DESCRIPTION
Three git identities in this repository belong to the same person. This maps them onto one.

| identity | commits |
|---|---|
| `Garit32 <valorantgovol1@…>` | 77 |
| `Darren <xthom2001@…>` | 16 |
| `Darren Wang <…Garit32@users.noreply…>` | 3 |

`git shortlog -sn --all` goes from four rows for two people to two:

```
107  Marvel Harisson
 96  Darren Wang
  3  dependabot[bot]
```

The note this replaces said Garit32 was "a separate contributor". That was wrong. `xthom2001` is a secondary GitHub account — created 2026-04-26, no repositories — and `Garit32` is the main one.

## What this does not fix

GitHub does not read `.mailmap`. Its contributor graph, and the notes produced by `generate_release_notes`, come from the commit author **email** and which account has that email verified.

That is why [v1.2.4](https://github.com/INo-xious/stockbit-mcp/releases/tag/v1.2.4) credits only one contributor: exactly one pull request was merged in its range, and the ten commits authored by Darren went straight to `main`, where the generator cannot see them.

Two things fix it, and neither is a history rewrite:

1. **Verify `xthom2001@gmail.com` on the Garit32 account.** GitHub re-attributes every past commit with that address retroactively.
2. **Land work through pull requests**, as `CONTRIBUTING.md` already requires — which is what this PR is doing.

Rewriting the commit authors instead would change every SHA from the first rewritten commit on, orphan the `v1.2.4` tag and its Release, and break the SLSA provenance attestation binding the published npm tarball to commit `121521f`.

## Risk

None to the build. `.mailmap` affects only what git displays; no source, test, manifest or workflow is touched, and the version is unchanged, so `publish.yml` will correctly decline to publish.