### PR TITLE
Phase 7: the movers surface, twelve report items, and the login.lock hole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,105 @@ name; see [`CONTEXT.md`](CONTEXT.md) for the rest of the evidence ladder.
 
 ### Added
 
+- **`market_movers` reaches every view Stockbit's own Movers dialog shows.** `mover_type` is now
+  sent, as a **closed** vocabulary of the eight members the server was seen to echo back on
+  2026-09-01: `topGainer`, `topLoser`, `topValue`, `topVolume`, `topFrequency`, `netForeignBuy`,
+  `netForeignSell`, `bigMoneyNetValue`.
+
+  The echo is what makes those eight evidence rather than guesses, and a control is what makes the
+  echo trustworthy: `MOVER_TYPE_DEFINITELY_NOT_REAL` answers 400, so this endpoint rejects members
+  it does not know instead of silently serving its default. That is the failure mode which hid the
+  `topGainer`/`topgainer` hotlist bug for months, and it is absent here. The result reports the
+  **echo** as `view` — what the server says it served — never what was requested.
+
+  The dialog's ninth tab, IEP/IEV, is deliberately **not** an enum member: ten spellings of it were
+  refused. It is a field, `iepiev_detail`, carried on every row of every view, projected as `iepIev`
+  and only meaningful during pre-opening. Shipping it as a member would have told callers the server
+  accepts a value nobody has seen it accept.
+
+  Rows come from `data.mover_list` with `readFrom` naming each wire key, `unmappedKeys` for what the
+  projection does not recognise, and the raw row kept. `limit` is honoured and capped at 50 by the
+  service; `page` is ignored; the payload's own `pagination` block reads all zeros on every call and
+  is therefore **not** passed through, because a `has_next: false` that is always false is not an
+  answer about whether more rows exist.
+
+### Fixed
+
+- **`calendar_today` reported "no corporate actions today" while the response carried 19 of them.**
+  The reader took the first array-valued key, and the payload is buckets whose first bucket
+  (`bonus`) is empty — so a day holding a dividend, eight economic events, a RUPS and nine warrants
+  read as nothing, with the rows sitting unread in `meta`. Every bucket is now returned, tagged with
+  its kind, and `date` comes from the response's own `today` instead of `null`.
+
+- **`top_movers` is a nine-symbol hotlist, and now says so.** It returned the same nine symbols at
+  `limit` 5, 25, 50 and 100 — the service ignores `limit` — so it was never a market-wide ranking.
+  That also disposes of a reported sort bug: a contiguous descending run of nine changes is what a
+  correct sort over nine symbols looks like. `market_movers` is the market-wide surface, and the two
+  disagreeing is expected rather than evidence either is wrong.
+
+- **`prices_batch` does not batch.** Comma-joining symbols returns an empty list and the repeated-key
+  form is a hard 400 (`too many values for field "stock_code"`), so there is no encoding that
+  batches — the route takes one `stock_code` and returns a price *series*. More than one symbol is
+  now refused locally rather than sent to come back empty, because an empty list reads as a claim
+  about the market when the truth is a claim about the request.
+
+- **`price_market` could not be called at all**, and now says so instead of offering arguments. It
+  answers 400 with **no** query parameters, which is what settles it: if sending nothing is also an
+  error, no combination of arguments is the fix. It names `orderbook`'s `market_data[]`, which
+  already returns the per-board split.
+
+- **`chart_series`'s `raw: true` escape hatch read a different endpoint from the one it exists to
+  diagnose.** It called `/charts/:symbol` while the projection reads `/charts/:symbol/daily`, and
+  the two do not share a timeframe vocabulary — the first refuses `1w` outright and answers
+  `{chart_points: []}` for everything else. So `1w` errored and `1m` came back empty, and a caller
+  read that emptiness as "the drift is gone".
+
+- **`broker_activity` sent a `period` the endpoint refuses.** Every member of the ten-value
+  `TB_PERIOD_*` enum answers 400 here — including the one its sibling `broker_distribution` accepts
+  — while omitting it returns rows. It is no longer sent, and `broker_activity_transaction` joins
+  the row containers, so the tool stops reporting `count: 0` beside a `dataKeys` that names the
+  container the rows were in.
+
+- **`broker_top` put the biggest broker last.** Rows arrive sorted **ascending** by `total_value`
+  and `limit` is ignored, so a tool documented as "which brokers moved the most" led with the
+  smallest of 89. Now sorted descending client-side and said so.
+
+- **Payloads carrying broker- or foreign-derived figures now say which session they are from.**
+  Measured after the ~18:00 WIB broker release, `running_trade`, `broker_flow_intraday` and
+  `market_movers` all roll forward to the current day, and `is_show_net_foreign` flips false to true
+  across that release — so figures carrying yesterday's date beforehand are correct and unpublished,
+  not stale. `price_bands` carries an explicitly **null** `dataAsOf` with a note, because the
+  orderbook payload has no date and fetching one from another endpoint would attribute one route's
+  date to another's numbers.
+
+- **`orderbook` names its units.** Its `volume` is SHARES while `technicals`' `volumeLots` is LOTS,
+  reconciling ×100 — in a payload that also labels its depth figures `lot` beside a `volume` in
+  shares. Two units under similar names in one response is a silent-wrong-answer generator.
+
+- **`stockbit-auth login` drove the shared browser profile without taking `login.lock`.** Gate 5 of
+  automatic recovery is "`login.lock` must be free", so it read free for the whole time a CLI login
+  was open — and an unattended recovery could launch a second browser onto the profile where
+  someone was at that moment typing their password. The documented cost of that collision is eleven
+  orphaned browser processes and a `SingletonLock` that blocked every later login.
+
+  The lock is now released on **SIGINT and SIGTERM as well as `exit`**: node does not run `exit`
+  listeners when a signal terminates the process, and this command hands a human fifteen minutes to
+  type, so Ctrl-C is the ordinary way to cancel it. Releasing only on `exit` would have leaked the
+  lock for twenty minutes on the commonest path — worse than never taking it.
+
+- **A failed token refresh no longer reports a network outage as a dead credential.** `refreshOnce`
+  labelled every non-ok refresh `kind: "auth"`, so a 502 was indistinguishable from a revoked
+  session. It now routes through `kindForStatus`, which already encoded the rule, rather than a
+  second copy of it.
+
+### Changed
+
+- **ADR-0011's status now claims exactly what has been observed.** The recovery path has never been
+  run against a live Stockbit session, so end to end it is **Projected**; the gates, the latch and
+  the redaction are verified offline and are stated as such. An attempt on 2026-09-01 found *why*
+  nobody has seen it run: `ensureFresh` adopts the browser's own access token before any refresh, so
+  a dead stored credential does not produce a 401 while the browser session is alive.
+
 - **A dead market-data session can now repair itself once, unattended, behind a switch.** Every
   signal for a dead session already existed and not one of them acted: the health journal records
   refusals, `status` computes `main.health: "failing"` and `webSession.rejected`, and a 401 becomes a

--- a/bin/stockbit-auth.ts
+++ b/bin/stockbit-auth.ts
@@ -166,8 +166,26 @@ async function cmdImportHar(argv: string[]): Promise<void> {
  * automatic recovery is refused by a process that is no longer running.
  *
  * `process.exit` DOES emit `exit`, and `DirLockRelease` is synchronous and idempotent — which is
- * the whole reason it can be an exit listener at all. A signal that kills the process outright
- * still leaks, and that is the case `LOGIN_LOCK_STALE_MS` is for.
+ * the whole reason it can be an exit listener at all.
+ *
+ * ## Why SIGINT and SIGTERM are handled too, and why that is not belt-and-braces
+ *
+ * Node does **not** run `exit` listeners when a signal terminates the process by default — measured,
+ * not assumed: a script that registers one and then `process.kill(process.pid, "SIGINT")` exits 130
+ * without printing from the listener. So an `exit` listener alone would leak the lock on **Ctrl-C**,
+ * and Ctrl-C is not an edge case here — this command gives a human fifteen minutes to type into a
+ * browser window, so interrupting it is the ordinary way to change your mind.
+ *
+ * That would have been a REGRESSION rather than a leftover risk. Before the lock existed here, a
+ * Ctrl-C during a CLI login cost nothing; with an `exit`-only release it would cost twenty minutes
+ * in which every login — this CLI, the MCP tool, and every unattended recovery — is refused by a
+ * process that is no longer running. Taking a lock is only an improvement if releasing it is at
+ * least as reliable as not having taken it.
+ *
+ * The handlers release and then re-raise with the default disposition, so the exit STATUS a caller
+ * sees is still the signal's (130 for SIGINT), not a `process.exit(0)` that would tell a script the
+ * login succeeded. `kill -9` still leaks, and that is the case `LOGIN_LOCK_STALE_MS` is genuinely
+ * for.
  *
  * Held for the rest of the command rather than just the capture, deliberately: a CLI login IS the
  * command, and the proof step that follows it rotates the credential the profile is holding.
@@ -183,6 +201,16 @@ async function holdLoginLock(): Promise<void> {
     process.exit(1);
   }
   process.once("exit", release);
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.once(signal, () => {
+      release();
+      // Restore the default disposition and re-raise, so the process dies of the signal it was
+      // sent and reports the status that goes with it. `process.exit(0)` here would tell a calling
+      // script that an interrupted login had succeeded.
+      process.removeAllListeners(signal);
+      process.kill(process.pid, signal);
+    });
+  }
 }
 
 async function cmdLogin(argv: string[]): Promise<void> {

--- a/bin/stockbit-auth.ts
+++ b/bin/stockbit-auth.ts
@@ -39,6 +39,7 @@ import {
 } from "../src/settings.js";
 import { emptyLedger, loadLedger, paperLedgerPath, saveLedger, snapshot } from "../src/trading/paper.js";
 import { captureNeedsProof, captureViaBrowserLogin, defaultProfileDir } from "../src/auth/login.js";
+import { acquireLoginLock } from "../src/auth/loginlock.js";
 import { clearBrowserProfile } from "../src/auth/browserprofile.js";
 import { clearWebSession } from "../src/auth/websession.js";
 import { clearAccessCache } from "../src/auth/accesscache.js";
@@ -141,7 +142,54 @@ async function cmdImportHar(argv: string[]): Promise<void> {
   if (!result.accessOk) process.exit(1);
 }
 
+/**
+ * Take `login.lock` for the rest of this process, or refuse and exit.
+ *
+ * The lock is what stops two participants driving `~/.stockbit/browser-profile` at once, and until
+ * P7g this bin was the one participant that never took it — while being the participant the MCP
+ * `login` tool's own comment names ("a second server instance (a different client, or the CLI)").
+ * The hole was not theoretical: gate 5 of automatic login recovery is "login.lock must be free", so
+ * it read FREE for the whole time a `stockbit-auth login` was open, and an unattended recovery
+ * could launch a second browser onto the profile where the user was at that moment typing their
+ * password. The documented cost of that collision is eleven orphaned browser processes, a manual
+ * `pkill`, and a `SingletonLock` that blocked every later login — the incident `reap_orphans` was
+ * written for.
+ *
+ * ## Why an `exit` listener rather than `try`/`finally`
+ *
+ * Because `finally` does not run on `process.exit`, and the two handlers that take this lock exit
+ * that way from seven places between them — "No session captured", "nothing reached the store", an
+ * already-expired token and a failed proof in `cmdLogin`; a failed capture and a failed test
+ * refresh in `cmdTradingLogin`; and the top-level `main().catch` under both. A `finally` would
+ * cover the throws and leak the lock on every explicit exit, and a leaked lock is exactly the
+ * stale-lock problem the lock exists to prevent: twenty minutes in which every login and every
+ * automatic recovery is refused by a process that is no longer running.
+ *
+ * `process.exit` DOES emit `exit`, and `DirLockRelease` is synchronous and idempotent — which is
+ * the whole reason it can be an exit listener at all. A signal that kills the process outright
+ * still leaks, and that is the case `LOGIN_LOCK_STALE_MS` is for.
+ *
+ * Held for the rest of the command rather than just the capture, deliberately: a CLI login IS the
+ * command, and the proof step that follows it rotates the credential the profile is holding.
+ */
+async function holdLoginLock(): Promise<void> {
+  const release = await acquireLoginLock();
+  if (!release) {
+    // The same shape the `login` tool refuses with — what is held, and what to go and finish —
+    // naming the holders a terminal is likely to be racing rather than the ones a client is.
+    logStderr("Another login is already in progress — a lock is held on the browser profile,");
+    logStderr("probably by a running stockbit-mcp server or a second terminal.");
+    logStderr("Finish or cancel that one, then run `stockbit-auth status`. Nothing was opened.");
+    process.exit(1);
+  }
+  process.once("exit", release);
+}
+
 async function cmdLogin(argv: string[]): Promise<void> {
+  // Before the first line of output, so a refusal cannot claim a browser is opening. Unconditional,
+  // including `--fresh-profile`: the `login` tool takes the lock for a fresh profile too, and a
+  // login is a login — the second window is confusing even when the two profiles differ.
+  await holdLoginLock();
   logStderr("Opening a browser for a one-time Stockbit login…");
   const result = await captureViaBrowserLogin({
     profileDir: argv.includes("--fresh-profile") ? "fresh" : undefined,
@@ -396,6 +444,15 @@ async function cmdTradingLogin(argv: string[]): Promise<void> {
     // PIN prompt is a MODAL that appears when a buy or sell is clicked, anywhere on the site. So
     // this opens the site and says what to click; a URL here could only ever be wrong again.
     const startUrl = process.env.STOCKBIT_TRADING_URL || "https://stockbit.com/";
+    // The same asymmetry `cmdLogin` had: this branch drives `~/.stockbit/browser-profile` through
+    // the very same `captureViaBrowserLogin`, so it is a second participant in the collision the
+    // lock exists to prevent — a PIN modal in one window and an unattended recovery launching into
+    // the same profile is the same wreck whichever credential is being captured.
+    //
+    // Only this branch. The PIN path below opens nothing: it posts the six digits to carina and
+    // never touches a browser profile, so locking it would refuse a login that cannot collide with
+    // anything — and `bootstrap` and `import-har` are left alone for the same reason.
+    await holdLoginLock();
     logStderr("Opening the logged-in browser so Cloudflare sees a real one.");
     logStderr("Click Buy or Sell on any stock in that window — the 6-digit PIN prompt appears as a");
     logStderr("pop-up. Enter it there. There is no separate trading page, so nothing to navigate to.");

--- a/docs/PENDING-VERIFICATION.md
+++ b/docs/PENDING-VERIFICATION.md
@@ -539,3 +539,46 @@ reproduced from a capture.
 
 `today` is present, so `date` can stop being `null`.
 
+### P7g item 3 — the recovery path was driven against a live account, and it did not run
+
+The attempt ADR-0011 has been waiting for. Run last, deliberately, because it breaks the session
+everything else depends on; the store was backed up first and restored afterwards, and live calls
+were re-verified working after the restore.
+
+**Method.** The stored `main` refresh token was replaced with a well-formed but dead JWT (future
+`exp`, nonsense signature, so it is STOCKBIT that rejects it rather than anything local), the shared
+access cache was cleared, and the **built** server — the only entry point that calls
+`armAutoRelogin()` — was started with `STOCKBIT_AUTO_RELOGIN=1` and no `STOCKBIT_NO_BROWSER`, then
+asked for a quote over stdio.
+
+**Result: the quote answered in 0.3 s and recovery never ran.** No browser opened, no 401 was
+raised, and `access.enc` was still empty afterwards — so nothing refreshed.
+
+**Why, and this is the finding.** `ensureFresh` has a **level three**
+(`src/auth/session.ts`, `domain === "main" && slotState.forcedRefreshes === 0`) that adopts the
+**browser's own access token** out of the web session before any refresh is attempted. With a live
+browser session, a dead stored refresh token therefore produces no 401 at all — the request is
+served from the browser's copy, which is exactly what that level was built to do.
+
+So the window in which automatic recovery can fire is **narrower than "the credential died"**. All
+three must hold at once:
+
+1. the stored refresh token is rejected by Stockbit, **and**
+2. the web session's ACCESS token is expired or unreadable, so level three declines — note it is
+   skipped anyway once `forcedRefreshes > 0`, which is the path a real 401 takes, **and**
+3. the web session's REFRESH token is still alive, because gate 4 requires
+   `webSessionHealth().likelyValid === true` and that verdict is computed from the refresh token.
+
+Conditions 2 and 3 are the interesting pair: the same artefact must be half dead and half alive, in
+the right halves. That is a real state — a web session whose access token has aged out while its
+refresh token has days left is ordinary — but it is not the state a tester lands in by killing the
+stored credential, which is why this path has never been observed.
+
+**What is therefore still unmeasured:** the harvest itself, and the ~3 s figure. This run did not
+reach `attemptAutoRelogin`, so it neither confirms nor refutes it. ADR-0011 stays **Projected** on
+the strength of this, and now says so with a reason rather than an absence.
+
+**To settle it:** expire the web session's ACCESS token while leaving its REFRESH token alive, then
+repeat the method above. `scripts/p7-recovery-probe.mjs` in the P7 worktree is the harness minus
+that one step.
+

--- a/docs/PENDING-VERIFICATION.md
+++ b/docs/PENDING-VERIFICATION.md
@@ -334,3 +334,208 @@ narrower than the hole it replaces, and unmeasured beyond that.
 
 **To settle it:** print `os.tmpdir()` from each client that runs this server on the same machine.
 
+---
+
+## Probed live on 2026-09-01, ~18:15–18:55 WIB (P7a)
+
+A third live pass, against a real account, on a **trading day after the ~18:00 WIB broker release**
+and with the market shut. The timing is the point: it is the only window in which the R1/R2/R3
+staleness question can be answered, and it settles the `MOVER_TYPE_*` vocabulary by echo rather than
+by rows, which needs no open session at all.
+
+Every row below is a transcript. Where a value was refused, the refusal is the finding.
+
+### The `MOVER_TYPE_*` vocabulary — settled by echo, with a control
+
+`/order-trade/market-mover` echoes `mover_type` back, so an accepted value returns as what was sent.
+The decisive addition is a **deliberate nonsense control**: `MOVER_TYPE_DEFINITELY_NOT_REAL` answers
+**400 `Your request is invalid`**. This endpoint therefore *rejects* unknown members rather than
+silently falling back to its default — which is what makes every ACCEPTED verdict below evidence
+rather than inference, and defeats this API's usual 200-with-the-default failure mode.
+
+| Member | Verdict |
+|---|---|
+| `MOVER_TYPE_TOP_VALUE` | **ACCEPTED** — echoed verbatim |
+| `MOVER_TYPE_BIG_MONEY_NET_VALUE` | **ACCEPTED** — echoed verbatim (was bundle-only until now) |
+| `MOVER_TYPE_TOP_GAINER` | **ACCEPTED** — echoed verbatim |
+| `MOVER_TYPE_TOP_LOSER` | **ACCEPTED** — echoed verbatim |
+| `MOVER_TYPE_TOP_VOLUME` | **ACCEPTED** — echoed verbatim |
+| `MOVER_TYPE_TOP_FREQUENCY` | **ACCEPTED** — echoed verbatim |
+| `MOVER_TYPE_NET_FOREIGN_BUY` | **ACCEPTED** — echoed verbatim |
+| `MOVER_TYPE_NET_FOREIGN_SELL` | **ACCEPTED** — echoed verbatim |
+| `MOVER_TYPE_IEP_IEV` | 400 |
+| `MOVER_TYPE_IEPIEV`, `_IEV`, `_IEP`, `_IEP_IEV_DETAIL`, `_INDICATIVE`, `_INDICATIVE_EQUILIBRIUM`, `_PRE_OPENING`, `_PREOPENING`, `_IEP_CHANGE`, `_TOP_IEP` | 400, all ten |
+| `MOVER_TYPE_TOP_FREQ`, `_FOREIGN_BUY`, `_FOREIGN_SELL`, `_TOP_GAINERS`, `_TOP_LOSERS` | 400 — near-miss spellings, recorded so nobody re-guesses them |
+
+**Eight members are settled. The IEP/IEV tab has no `mover_type` and must not be given one.**
+
+### IEP/IEV is a FIELD, not a view
+
+`iepiev_detail` is carried on **every row of every view**:
+`{iep, iev, ieval, iep_change, iep_change_prev, iep_price_diff, iep_prev_price_diff}`, each a
+`{raw, formatted}` pair. On this reading every value was `0`/`"-"`, which is expected: IEP/IEV is the
+indicative equilibrium price computed during **pre-opening (08:45–09:00 WIB)** and there is none
+outside it.
+
+So the UI's eighth tab is reachable by projecting a field, not by requesting a view. That closes the
+"all eight tabs" goal without shipping a guessed enum member.
+
+### `market-mover` shape and paging
+
+| | |
+|---|---|
+| Row container | `data.mover_list` — **50 rows with the market shut** |
+| Row fields | `stock_detail{code,name,icon_url,has_uma,notations,corpaction}`, `price`, `change{value,percentage}`, `value{raw,formatted}`, `volume{raw,formatted}`, `frequency{raw,formatted}`, `net_foreign_buy`, `net_foreign_sell`, `net_buy`, `net_sell`, `iepiev_detail`, `big_money_net_value`, `buy_value_percentage`, `sell_value_percentage`, `big_money_buy_value_percentage`, `big_money_sell_value_percentage`, `bid_percent`, `catalog_detail`, `market_cap` |
+| `limit` | **HONOURED.** `limit=5` → 5 rows; `limit=100` → 50, so 50 is the ceiling |
+| `page`, `per_page` | **IGNORED.** `page=1` returns the same 50 rows |
+| `data.pagination` | **DEAD.** Always `{page:0, limit:0, has_next:false, has_prev:false}` regardless of what is sent. It must be reported absent, never projected as meaningful — a `has_next:false` that is always false is not an answer about paging |
+| Provenance | `mover_type` (echo), `is_show_net_foreign`, `net_foreign_updated_at`, `net_foreign_session_info{raw,formatted,date,is_last_session}` |
+
+`market_cap` came back `null` on every row.
+
+### R1 / R2 / R3 — the post-18:00 adjudication. **All three roll forward. Not staleness.**
+
+The report asked whether these serve a stale date. Measured after the broker release on the same
+trading day, every one of them serves **today**:
+
+| Route | What it said |
+|---|---|
+| `runningTrade` (`symbols=BBRI&order_by=1`) | `data.date = "2026-09-01"` — today |
+| `runningTradeChart` (broker_flow_intraday) | `from = to = "2026-09-01"`, `date_session_info = "1 Sep 2026"` — today |
+| `marketMover` | `net_foreign_updated_at = "2026-09-01"`, `net_foreign_session_info.date = "2026-09-01"`, `is_last_session = true` — today |
+| `marketMover` | `is_show_net_foreign = **true**` — the field report saw `false` intraday |
+
+**This settles the reclassification.** R1, R2 and R3 are *documentation* items, not staleness bugs:
+the data is correct and fails to announce which session it is from. `is_show_net_foreign` flipping
+false→true across the release is the mechanism, observed on both sides.
+
+`brokerDistribution` already carries `date_info`, `start_date` and `end_date`; `brokerTop` carries
+`data.date{from,to,idx}`; `brokerActivity` carries `from`/`to`. Three of the four payloads that need
+a `dataAsOf` already contain one.
+
+### NEW, not in the report: `data_last_updated` is WIB stamped as UTC
+
+`runningTradeChart` returned `data_last_updated = "2026-09-01T16:28:44Z"`. At the moment of the call
+it was **11:28 UTC**, so a `Z` timestamp of 16:28 is five hours in the future. 16:28 **WIB** is
+minutes after the 16:15 close, which is the only reading that makes sense. The `Z` suffix is wrong.
+
+Anything that parses this field as UTC gets a timestamp five hours ahead of reality. It is the same
+class as the mixed units in cross-cutting observation 3, and it should be read as WIB and re-stamped,
+or surfaced verbatim with the discrepancy named — never parsed as the `Z` claims.
+
+### D5 — the hotlist universe. **Nine symbols, and `limit` does nothing.**
+
+`/emitten/hotlist/topgainer` at `limit` = 5, 25, 50 and 100 returned the **same nine rows every
+time**: `SOTS, APLI, KOBX, BOBA, ENAK, DIVA, UNIC, DFAM, HBAT`.
+
+So `limit` is ignored *and* the universe is nine. This confirms the plan's second correction: the
+report's "not ranking by change" reading is wrong — a contiguous descending sort over nine symbols is
+what a correct ranking over a nine-symbol universe looks like. There is no sort bug to fix; the tool
+must state its universe.
+
+For contrast, `market-mover`'s `MOVER_TYPE_TOP_GAINER` returned 50 rows whose codes include
+structured warrants (`ELSAZPCF7A`, `MAPIHDCZ6A`, `ACESDRCU6A`). **The two tools serve genuinely
+different universes**, which is the repo's existing position on them and is now measured.
+
+### D7 — `prices_batch` is not a batch endpoint
+
+| Request | Result |
+|---|---|
+| `stock_code=BBRI` | 200, `data.prices` = **array(20) of bare numbers** (`[3280, …]`) |
+| `stock_code=BBRI,BBCA,TLKM` | 200, `data.prices` = **array(0)** |
+| `stock_code=BBRI&stock_code=BBCA&stock_code=TLKM` | **400 `too many values for field "stock_code"`** |
+| `stock_code[]=…` (repeated) | **400 `too many values for field "stock_code"`** |
+| `symbols=BBRI,BBCA,TLKM` | 400 `Silahkan Periksa permintaan` |
+| `stock_code=BBRI\|BBCA\|TLKM` | 200, empty |
+
+`/company-price-feed/prices` takes **one** `stock_code` and returns a **series of prices for it** —
+not one last price per symbol. The repeated-key encoding the report proposed is explicitly refused,
+so there is no encoding left to find. **The tool is built on a false premise**, and the honest fix is
+to say the route is single-symbol rather than to keep returning an empty batch that reads as "no
+prices".
+
+### D9 — `price_market` cannot be called at all
+
+`/company-price-feed/prices/BBRI/market` answers **400 `Silahkan Periksa permintaan` with no
+parameters at all**, and with every one of: `market` = `REGULER`, `RG`, `regular`, `REGULAR`, `TN`,
+`NG`, `CASH`, `ALL`, `MARKET_TYPE_REGULAR`, `MARKET_TYPE_ALL`, `BOARD_REGULAR`, `1`, `0`; and with
+the keys `board`, `market_type` and `type`.
+
+**This is not a vocabulary problem.** A bare call with no query at all is refused, so no argument
+combination can fix it. The tool should say it cannot be called and point at `orderbook`'s
+`market_data[]`, which already returns the per-board split.
+
+### D10 — two chart routes, two vocabularies, and `1w` is the discriminator
+
+| timeframe | `/charts/:symbol` | `/charts/:symbol/daily` |
+|---|---|---|
+| `1w` | **400 `Kurun waktu tidak valid`** | **200** |
+| `1m`, `1d`, `3m`, `ytd`, `1y` | 200 | 200 |
+| `1D`, `1W`, `1M`, `daily`, `weekly`, `5`, `15`, `60`, `1`, `D`, `W` | 400 | — |
+
+The two routes also return **different shapes**. `/charts/:symbol` answers `{chart_points: []}` — a
+near-empty container. `/charts/:symbol/daily` answers the rich payload the projection reads:
+`prices`, `cagr`, `change`, `drawdown`, `markingpoint`, `percentage`, `timeframe`, `xaxisopt`,
+`previous`, `line_weight`, `previous_timeframe_price`, `chart_type`, `interval_in_minutes`,
+`allowed_chart_type`, `max_candles`.
+
+That is the whole of D10, measured: `getChartRaw` reads `charts` while `getSeriesBars` reads
+`chartsDaily`, and hands the first the second's vocabulary. `1w` → 400 and `1m` → empty are both
+explained by the route being wrong, not the value.
+
+### D11 — `broker_activity` has no `period`, and the row container exists without one
+
+The control is what settles it:
+
+| Call | Result |
+|---|---|
+| `brokerDistribution` + `period=TB_PERIOD_LAST_1_DAY` | **200** |
+| `brokerActivity` + `period=TB_PERIOD_LAST_1_DAY` | **400** |
+| `brokerActivity` + all ten `BROKER_PERIODS` members | **400**, every one |
+| `brokerActivity` + `period=TB_PERIOD_DAILY`/`_1D`/`_ONE_DAY`/`_WEEKLY`/`_MONTHLY`/`DAILY`/`1D`/`daily` | **400**, every one |
+| `brokerActivity` + **no** `period` | **200, with rows** |
+| `brokerActivity` + `tb_period`/`periode`/`range`/`time_period` | 200 — unknown keys are silently ignored, so the 400 on `period` is a *validated* field refusing a value, not an unknown one |
+
+The same member that its sibling accepts is refused here. **`broker_activity` must stop sending
+`period`** and say the endpoint has no period filter; its window is fixed and already reported.
+
+Row container, from a call with no `period`:
+`data` = `{broker_activity_transaction, from, to, broker_code, broker_name}`. So
+**`broker_activity_transaction` belongs in `ROW_CONTAINERS`**, and `from`/`to` give the result its
+provenance for free.
+
+### D12 — `broker_top`: `limit` ignored, sorted ASCENDING, and the report's dead fields are alive
+
+| | |
+|---|---|
+| Row container | `data.list` — **89 rows** bare, at `limit=3` and at `limit=5` alike. `limit` is ignored |
+| Sort | **ASCENDING by `total_value`**, verified across all 89: first `22,485,000`, last `5,636,360,451,396`. The tool documented as "which brokers moved the most" puts the biggest broker last |
+| `sort_by=total_value`, `sort_by=TOTAL_VALUE`, `order_by=desc`, `sort_direction=DESC` | 200 — accepted, and **none reversed the order** |
+| `order=desc`, `sort=desc` | 400 — recognised fields refusing a value |
+| Provenance | `data.date{from, to, idx}`, all `2026-09-01` |
+| Row shape | `{code, name, investor_type, total_value, net_value, buy_value, sell_value, total_volume, total_frequency, group}` — **plain strings, not `{raw,formatted}`** |
+
+**Correction to the report.** It records `net_value`, `buy_value` and `sell_value` as `"0"` on every
+row and calls them three dead fields. On this reading all three carry **89 distinct values** —
+e.g. first row `net_value: "-15025000"`, `buy_value: "3730000"`, `sell_value: "18755000"`. They are
+populated and must not be reported absent. Whatever produced the zeroes was not the schema.
+
+No `sort_by` value reverses the order, so the descending sort has to be done client-side and said so.
+
+### D13 — `calendar_today` is buckets, and the first one is empty
+
+`/corpaction` returned, in this order:
+
+```
+bonus: 0    dividend: 1    economic: 8    ipo: 0    pubex: 0    rightissue: 0
+rups: 1     stock_reverse: 0    stocksplit: 0    tender: 0    warrant: 9
+stock_dividend: 0    today: <string>
+```
+
+`rowsOf` (`src/core/corpaction.ts:80`) takes the **first** key whose value is an array of records.
+`bonus` is first and empty, so it binds there and reports `rows: []` — while **19 real rows**
+(dividend 1, economic 8, rups 1, warrant 9) go unread into `meta`. Exactly the reported defect,
+reproduced from a capture.
+
+`today` is present, so `date` can stop being `null`.
+

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -55,7 +55,7 @@ Prices, depth, movers, bars, the session clock.
 | Tool | Kind | When to use | Evidence | Inputs |
 |---|---|---|---|---|
 | `quote` | read | Real-time quote for an IDX symbol: last price, change, and best bid/offer. | Observed | symbol* |
-| `top_movers` | read | Top gainers, losers, or most-active IDX stocks (hotlist). | Observed | type*, limit |
+| `top_movers` | read | Stockbit's HOTLIST — a small curated list, NOT a market-wide ranking. | Observed | type*, limit |
 | `trending` | read | Trending IDX stocks right now (community-driven). | Observed | — |
 | `sectors` | read | List IDX sectors (id, name). | Observed | — |
 | `intraday_prices` | read | Intraday minutely close-price series for a symbol (the basis for volume/price-move signals). | Observed | symbol*, interval |
@@ -66,12 +66,12 @@ Prices, depth, movers, bars, the session clock.
 | `running_trade` | read | The running-trade tape: individual prints as they cross the exchange. | Projected | symbol, action, limit, order_by, grouped |
 | `trade_book` | read | Traded volume broken down by price level for a session. | Projected | symbol, mode, data_modes, group_by, limit, chart |
 | `broker_flow_intraday` | read | Per-broker intraday flow for one symbol, minute by minute, returned exactly as Stockbit sends it. | Observed | symbol* |
-| `market_movers` | read | Market movers from the order-trade service. | Projected | limit |
+| `market_movers` | read | The market movers behind Stockbit's own Movers dialog — the market-wide ranking. | Observed | view, limit |
 | `top_stocks` | read | The order-trade service's top-stock list. | Projected | limit |
 | `order_queue` | read | The live order queue for one symbol: what is currently resting on the book. | Projected | symbol*, sort_by, limit |
 | `market_session` | read | Where the IDX trading day currently is: pre-opening, session 1, the midday break, session 2, post-closing, or shut. | Projected | — |
-| `prices_batch` | read | Last price for several symbols in one request. | Projected | symbols* |
-| `price_market` | read | One symbol's prices broken down by market board for a session. | Projected | symbol*, date, boards |
+| `prices_batch` | read | A price SERIES for ONE symbol. | Observed | symbols* |
+| `price_market` | read | DOES NOT WORK. | Projected | symbol*, date, boards |
 
 ## bandarmology
 
@@ -154,7 +154,7 @@ Dividends, splits, rights, the corporate calendar.
 |---|---|---|---|---|
 | `corporate_actions` | read | Corporate actions of ONE kind: dividends, rights issues, RUPS (shareholder meetings), bonus shares, splits, reverse splits, tender offers, warrants, public exp… | Observed | action_type*, symbol, limit |
 | `dividend_calendar` | read | Cash dividends AND stock dividends in one list, newest ex-date first. | Observed | symbol, limit |
-| `calendar_today` | read | Every corporate action happening across the whole market on ONE date, or day by day over a short range. | Projected | date, from, to |
+| `calendar_today` | read | Every corporate action happening across the whole market on ONE date, or day by day over a short range. | Observed | date, from, to |
 | `corporate_action_status` | read | UMA (unusual market activity) and IDX special-notation status for several symbols in ONE request. | Observed | symbols* |
 | `stock_conversion` | read | Warrant and rights conversion records for one issuer: the exercises that turned derivative instruments into ordinary shares, which is share-count dilution that… | Projected | symbol*, page, limit |
 | `ipo_pipeline` | read | Upcoming and recent IPOs, with whatever offering terms the row carries. | Observed | limit |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -154,7 +154,7 @@ Dividends, splits, rights, the corporate calendar.
 |---|---|---|---|---|
 | `corporate_actions` | read | Corporate actions of ONE kind: dividends, rights issues, RUPS (shareholder meetings), bonus shares, splits, reverse splits, tender offers, warrants, public exp… | Observed | action_type*, symbol, limit |
 | `dividend_calendar` | read | Cash dividends AND stock dividends in one list, newest ex-date first. | Observed | symbol, limit |
-| `calendar_today` | read | Every corporate action happening across the whole market on ONE date, or day by day over a short range. | Observed | date, from, to |
+| `calendar_today` | read | Every corporate action happening across the whole market on ONE date, or day by day over a short range. | Projected | date, from, to |
 | `corporate_action_status` | read | UMA (unusual market activity) and IDX special-notation status for several symbols in ONE request. | Observed | symbols* |
 | `stock_conversion` | read | Warrant and rights conversion records for one issuer: the exercises that turned derivative instruments into ordinary shares, which is share-count dilution that… | Projected | symbol*, page, limit |
 | `ipo_pipeline` | read | Upcoming and recent IPOs, with whatever offering terms the row carries. | Observed | limit |

--- a/docs/adr/0011-automatic-login-recovery.md
+++ b/docs/adr/0011-automatic-login-recovery.md
@@ -1,9 +1,32 @@
 # ADR-0011 — Automatic login recovery
 
-**Status.** Accepted.
+**Status.** Accepted and implemented — **never run against a live Stockbit session.**
 **Supersedes nothing.** Extends [ADR-0007](0007-auth-tools-in-the-server.md) (auth tools in the
 server) and depends on [ADR-0009](0009-browser-is-the-source-of-truth.md) (the browser is the source
 of truth).
+
+## What is verified, and what is not
+
+The same qualifier [ADR-0004](0004-order-entry.md) carries, for the same reason: this describes a
+thing the code does to a user's machine, and the description must not claim more than has been seen.
+Read it on the evidence ladder in [`CONTEXT.md`](../../CONTEXT.md).
+
+**Projected — the recovery end to end.** No 401 from Stockbit has ever driven this path in this
+repo. The suite is offline, `fetch` is stubbed, and every capture in it is injected. So "a dead
+session is silently replaced mid-task" is a projection from parts that work separately, not a
+behaviour anyone has watched happen here.
+
+**Verified offline — the safety properties, and these are the ones that matter.**
+`test/relogin.test.ts` holds each of them, and `test/reap.test.ts` the last half of the last:
+
+- every gate refuses in the state it exists for, and the five are independent;
+- the one-attempt latch is spent exactly once, and never by a gate — standing aside for a human who
+  is signing in leaves the attempt available;
+- a capture that comes back with nothing is reported as `harvest-failed`, never as a recovery;
+- no verdict and no error carries a token, and nothing reaped is reported by command line.
+
+That split is deliberate. The unverified half is "does it fix the session"; the verified half is
+"can it do harm while trying", and only the second is a reason the default could be wrong.
 
 ## The decision
 
@@ -27,7 +50,15 @@ action.
 
 And the action was known to work: when the API token is dead but the browser session is still alive,
 a forced login reads the credential straight out of the already-signed-in profile in about three
-seconds, with nobody typing anything. That path was confirmed working unattended.
+seconds, with nobody typing anything.
+
+Where that figure comes from, because it is quoted elsewhere and reads like a measurement: it is
+**the same field report**, from the account owner's own machine. Nothing in this repo has timed a
+harvest — the suite is offline and every capture in it is injected — so "~3 s" is one person's
+observation of the manual path this one automates, not a number produced by a call made here. It is
+recorded because it is what made the decision, and qualified because a reader deciding whether to
+set `STOCKBIT_AUTO_RELOGIN` should know which of the two it is. `UNATTENDED_TIMEOUT_MS` is 30 s, and
+that ceiling is what the code actually relies on.
 
 ## What "gated" means here
 
@@ -39,7 +70,7 @@ Five conditions, each closing a different way of doing harm. All five, every tim
 | `STOCKBIT_AUTO_RELOGIN` is set, parsed truthily | A window nobody opted into |
 | `STOCKBIT_NO_BROWSER` is not set | The existing no-browser contract |
 | `webSessionHealth().likelyValid` is **true** | Spending a rotation on a session already dead |
-| `login.lock` is free — taken with `timeoutMs: 0`, never queued | Two windows driving one browser profile |
+| `login.lock` is free — taken with `timeoutMs: 0`, never queued | Two windows driving one browser profile (every participant that can open one takes it: the `login` tool, this, and `stockbit-auth login` / `trading-login --browser`) |
 
 Plus: `main` only, and one attempt per process.
 
@@ -188,6 +219,11 @@ and tested registration-purity property in `src/tools/surface.ts`.
 - Recovery takes the same `login.lock` a human login takes, so the two can never drive one browser
   profile at once — in either direction. It never queues on it: a recovery that waits is a tool call
   that hangs, and there is nothing left to recover by the time someone finishes signing in.
+  - Amended 2026-09-01 (P7g): that was true of the `login` TOOL and not of the CLI, which took no
+    lock at all — so this gate read "free" throughout a `stockbit-auth login`, which is the one
+    participant the tool's own comment names. `stockbit-auth login` and `trading-login --browser`
+    now take it too, through the single `src/auth/loginlock.ts`, and release it on every exit path
+    including a failure. Three participants, one rule; `test/authcli.test.ts` holds both halves.
 - An auth failure keeps its own error `kind`. Recovery adds a sentence; it never reclassifies a
   transport failure as an authentication one, which would make a dropped Wi-Fi read as a dead
   session to every consumer that branches on `kind`.

--- a/docs/adr/0011-automatic-login-recovery.md
+++ b/docs/adr/0011-automatic-login-recovery.md
@@ -70,7 +70,7 @@ Five conditions, each closing a different way of doing harm. All five, every tim
 | `STOCKBIT_AUTO_RELOGIN` is set, parsed truthily | A window nobody opted into |
 | `STOCKBIT_NO_BROWSER` is not set | The existing no-browser contract |
 | `webSessionHealth().likelyValid` is **true** | Spending a rotation on a session already dead |
-| `login.lock` is free — taken with `timeoutMs: 0`, never queued | Two windows driving one browser profile (every participant that can open one takes it: the `login` tool, this, and `stockbit-auth login` / `trading-login --browser`) |
+| `login.lock` is free — taken with `timeoutMs: 0`, never queued | Two windows driving one browser profile. Every participant that drives the SHARED profile takes it: the `login` tool, this, and `stockbit-auth login` / `trading-login --browser`. `doctor` opens a browser and is deliberately not one — its self-tests run on their own throwaway profiles and cannot collide |
 
 Plus: `main` only, and one attempt per process.
 

--- a/docs/adr/0011-automatic-login-recovery.md
+++ b/docs/adr/0011-automatic-login-recovery.md
@@ -16,6 +16,23 @@ repo. The suite is offline, `fetch` is stubbed, and every capture in it is injec
 session is silently replaced mid-task" is a projection from parts that work separately, not a
 behaviour anyone has watched happen here.
 
+It was **attempted against a live account on 2026-09-01**, and the attempt is what turned this from
+an absence into a reason. The stored `main` refresh token was replaced with one Stockbit would
+reject and the access cache was cleared; the built server, armed and opted in, then answered a quote
+**in 0.3 s without opening anything**. Recovery did not run, and did not need to.
+
+The cause is `ensureFresh`'s **level three**, which adopts the browser's own access token before any
+refresh is attempted. While the browser session is alive, a dead stored credential does not produce
+a 401 at all. So this path needs three things at once — a rejected stored token, a web-session
+ACCESS token that has aged out (so level three declines), and a web-session REFRESH token still
+alive (because gate 4 tests exactly that). The same artefact has to be half dead in one half and
+alive in the other.
+
+That is an ordinary state in the wild and an awkward one to stage, which is the honest explanation
+for why nobody has watched this run. `docs/PENDING-VERIFICATION.md` records the method and the one
+remaining step. Until someone completes it, the ~3 s harvest figure remains a field report from the
+account owner's machine and nothing here has timed it.
+
 **Verified offline — the safety properties, and these are the ones that matter.**
 `test/relogin.test.ts` holds each of them, and `test/reap.test.ts` the last half of the last:
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,7 @@ unassigned rather than back-filled.
 | [0008](0008-paper-trading.md) | Paper trading: three modes, not two; the same order protocol against a local ledger | ACCEPTED 2026-08-24 |
 | [0009](0009-browser-is-the-source-of-truth.md) | The browser is the source of truth for the rotating token family; the store follows it | ACCEPTED 2026-08-26 |
 | [0010](0010-elicitation-is-decisive.md) | Elicitation is decisive: the human is asked first, and `confirm` cannot skip the ask | ACCEPTED and implemented 2026-08-28 — amends 0004, no new routes |
-| [0011](0011-automatic-login-recovery.md) | Automatic login recovery: one gated, unattended attempt to re-harvest a dead session | ACCEPTED and implemented 2026-09-01 — off by default, no new routes; first env var that RAISES a permission |
+| [0011](0011-automatic-login-recovery.md) | Automatic login recovery: one gated, unattended attempt to re-harvest a dead session | ACCEPTED and implemented 2026-09-01 — **never run against a live Stockbit session**; the gates are verified offline, the harvest end to end is Projected. Off by default, no new routes; first env var that RAISES a permission |
 
 ## Writing a new one
 

--- a/skills/bandar-check/SKILL.md
+++ b/skills/bandar-check/SKILL.md
@@ -15,11 +15,14 @@ meaningful before saying anything about who is on it.
    closes. Say so rather than quietly presenting half a day as a day.
 2. **`broker_summary symbol=… `** — the ledger. Every broker's buy and sell over the window.
    - `period` takes one of FIVE windows, and only these five: `LATEST`, `YESTERDAY`, `LAST_7_DAYS`,
-     `LAST_3_MONTHS`, `YEAR_TO_DATE`. The longer ten-value list belongs to `broker_activity`,
-     `broker_top` and `broker_distribution`, which are different endpoints; sending one of those
-     here is rejected, and `LAST_1_DAY` / `LAST_30_DAYS` return a 400 from Stockbit itself. Or give
-     `from`/`to` for an explicit range. Do not do both — the API ignores the dates and answers with
-     the latest session, silently.
+     `LAST_3_MONTHS`, `YEAR_TO_DATE`. The longer ten-value list belongs to `broker_top` and
+     `broker_distribution`, which are different endpoints; sending one of those here is rejected,
+     and `LAST_1_DAY` / `LAST_30_DAYS` return a 400 from Stockbit itself. Or give `from`/`to` for
+     an explicit range. Do not do both — the API ignores the dates and answers with the latest
+     session, silently.
+   - `broker_activity` has **no window at all**. Measured 2026-09-01: every value of `period`
+     answers 400 there, so the tool refuses it rather than sending it. Its window is the server's,
+     and it is reported back in `from`/`to` on the result — read those to date the rows.
    - `transaction_type` is `NET` or `GROSS`. **NET is the question people mean.** GROSS tells you
      who was busy; NET tells you who ended up holding.
    - `market_board` defaults to the regular board. `NEGO` and `TUNAI` are crossings and cash

--- a/src/analysis/analyze.ts
+++ b/src/analysis/analyze.ts
@@ -1120,6 +1120,21 @@ async function attempt<T>(label: string, run: () => Promise<T>): Promise<Attempt
 function refuseEmptyReport(pillars: Pillar[], causes: unknown[]): void {
   if (pillars.some((p) => p.status !== "missing")) return;
 
+  // By KIND here, and deliberately not by status — the opposite call from the two guards in
+  // `src/auth/session.ts` and `src/tools/system.ts`, for a reason worth stating because the
+  // asymmetry looks like an oversight.
+  //
+  // Those two guards unlock DESTRUCTIVE advice ("sign your browser out of Stockbit") and must be
+  // sure a credential was judged and refused, so they demand the 401. This is a PRIORITY: several
+  // sources failed, and it picks which failure the caller is told about. The most common auth
+  // failure that reaches here carries no status at all — `No Stockbit session stored`, raised
+  // before any request is made — and narrowing to 401/403 would drop exactly the case that most
+  // needs to be surfaced, leaving the user to read "no valuation metric could be located" on a
+  // machine that has never logged in.
+  //
+  // The 5xx that used to arrive here mislabelled `auth` is handled at the source now: `refreshOnce`
+  // derives its kind from the status, so an outage falls through to the `first` branch below and is
+  // rethrown as the `upstream` error it is, rather than jumping the queue as a dead session.
   const authFailure = causes.find((c) => c instanceof StockbitError && c.kind === "auth");
   if (authFailure) throw authFailure;
 

--- a/src/auth/loginlock.ts
+++ b/src/auth/loginlock.ts
@@ -4,8 +4,13 @@
  * Two browsers on one profile is not a slow login, it is a broken one. The documented cost, from
  * the incident that made `reap_orphans` exist: eleven orphaned browser processes, a manual `pkill`,
  * and a `SingletonLock` left in the profile that refused every later login until it was deleted by
- * hand. So every participant that can open a login window takes this lock first, and a holder is
+ * hand. So every participant that drives the SHARED profile takes this lock first, and a holder is
  * refused rather than queued.
+ *
+ * "Drives the shared profile" is the test, not "opens a browser" — `stockbit-auth doctor` opens one
+ * and is deliberately NOT a participant, because `captureSelfTest` and `harvestSelfTest` each run
+ * on their own `mkdtempSync` profile and so cannot collide with anything. Taking the lock there
+ * would refuse a real login on behalf of a self-test that could not have interfered with it.
  *
  * ## Why the rule lives here rather than at the call sites
  *

--- a/src/auth/loginlock.ts
+++ b/src/auth/loginlock.ts
@@ -1,0 +1,49 @@
+/**
+ * The one lock that serialises everything which drives `~/.stockbit/browser-profile`.
+ *
+ * Two browsers on one profile is not a slow login, it is a broken one. The documented cost, from
+ * the incident that made `reap_orphans` exist: eleven orphaned browser processes, a manual `pkill`,
+ * and a `SingletonLock` left in the profile that refused every later login until it was deleted by
+ * hand. So every participant that can open a login window takes this lock first, and a holder is
+ * refused rather than queued.
+ *
+ * ## Why the rule lives here rather than at the call sites
+ *
+ * It used to live at two of them, as two copies of `LOGIN_LOCK_STALE_MS` — with a comment on the
+ * second explaining that the duplication was deliberate because nothing under `src/auth/` may
+ * depend on `src/tools/`. That direction is right, and this module keeps it: `src/tools/system.ts`,
+ * `src/auth/relogin.ts` and `bin/stockbit-auth.ts` may all depend on `src/auth/`, and none of them
+ * depends on another. What was wrong was the NUMBER of copies. `bin/stockbit-auth.ts` was about to
+ * become a third, and three hand-kept copies of a staleness budget is a rule that will drift — a
+ * participant using a longer budget than its peers breaks a lock somebody is still legitimately
+ * holding, which is the exact failure the budget exists to prevent.
+ *
+ * What is deliberately NOT here is the refusal MESSAGE. Each caller names a different likely holder
+ * (a terminal, a second client, this very server mid-recovery) and a different next step, and one
+ * shared sentence would have to be vague about both. The lock is one rule; the sentence is three.
+ */
+import { acquireDirLock, type DirLockRelease } from "../util/dirlock.js";
+import { stockbitPath } from "../paths.js";
+
+/**
+ * How long the login lock is held before it is assumed to belong to a dead process.
+ *
+ * Generous because the operation is: the `login` tool gives a human fifteen minutes to type, and
+ * the CLI uses the same ceiling. Twenty minutes is long enough that a real login is never broken as
+ * stale, and short enough that a machine killed mid-login is not locked out until someone reboots.
+ */
+export const LOGIN_LOCK_STALE_MS = 20 * 60_000;
+
+/**
+ * Take the login lock, or report that someone else holds it. Never queues.
+ *
+ * `timeoutMs: 0` is part of the rule, not a tuning choice. Waiting is wrong for all three callers:
+ * a queued MCP tool call is a client timeout, a queued recovery is a hung tool call, and a queued
+ * CLI is a terminal that looks hung with no window to explain itself. The answer a caller needs is
+ * "no", immediately, with a sentence naming what to go and finish.
+ *
+ * Returns the release function, or null when the lock is held. Release is idempotent.
+ */
+export function acquireLoginLock(): Promise<DirLockRelease | null> {
+  return acquireDirLock(stockbitPath("login.lock"), { staleMs: LOGIN_LOCK_STALE_MS, timeoutMs: 0 });
+}

--- a/src/auth/relogin.ts
+++ b/src/auth/relogin.ts
@@ -8,9 +8,17 @@
  * error message at the call site. All three are REPORTS. When the session died mid-task the user
  * still had to notice, read, and re-run the login themselves — twice in one session.
  *
- * The recipe this implements was confirmed on the wire: when the API token is dead but the BROWSER
- * session is still alive, a forced login harvests a working credential out of the profile that is
- * already signed in, in about three seconds, with nobody typing anything.
+ * The recipe this implements: when the API token is dead but the BROWSER session is still alive, a
+ * forced login harvests a working credential out of the profile that is already signed in, in about
+ * three seconds, with nobody typing anything.
+ *
+ * That sentence is a FIELD REPORT — the account owner running the manual path on their own machine
+ * — and not a measurement made here, which an earlier version of this comment blurred by calling it
+ * "confirmed on the wire". Nothing in this repo has ever timed a harvest, or run this module against
+ * a live Stockbit session at all: the suite is offline and every capture in it is injected. What is
+ * verified here is that the gates refuse, that the one attempt is spent exactly once, and that no
+ * verdict carries a token. The three seconds is why the module exists; `UNATTENDED_TIMEOUT_MS`
+ * below, at 30 s, is what the code actually relies on. ADR-0011 records the same split.
  *
  * ## A harvest is not silent, and the brief's wording hides that
  *
@@ -52,8 +60,7 @@
  */
 import { browserSuppressed } from "../desktop/browser.js";
 import { redact } from "../redact.js";
-import { acquireDirLock } from "../util/dirlock.js";
-import { stockbitPath } from "../paths.js";
+import { acquireLoginLock } from "./loginlock.js";
 import type { TokenDomain } from "../http/transport.js";
 import { getStore, type StoreSlot } from "./store.js";
 import { webSessionHealth } from "./websession.js";
@@ -72,14 +79,6 @@ import { webSessionHealth } from "./websession.js";
  * longer only makes a failed recovery more expensive than the failure it was trying to repair.
  */
 export const UNATTENDED_TIMEOUT_MS = 30_000;
-
-/**
- * Staleness budget for `login.lock`, matching the one `src/tools/system.ts` uses on the same file.
- *
- * Deliberately duplicated rather than imported: nothing under `src/auth/` may depend on
- * `src/tools/`, and the value belongs to the LOCK, which both paths now take.
- */
-const LOGIN_LOCK_STALE_MS = 20 * 60_000;
 
 export type ReloginOutcome =
   /** This process never armed recovery — the CLI, the batch backfill, a test. */
@@ -341,11 +340,10 @@ export async function attemptAutoRelogin(
   // a SECOND browser on one profile, which is the condition that produces the orphaned processes
   // this phase also has to clean up.
   //
-  // `timeoutMs: 0` — never queue. A recovery that waits is a tool call that hangs, and by the time a
-  // person has finished signing in there is nothing left to recover.
-  const release = deps.capture
-    ? () => {}
-    : await acquireDirLock(stockbitPath("login.lock"), { staleMs: LOGIN_LOCK_STALE_MS, timeoutMs: 0 });
+  // `acquireLoginLock` never queues, and that is part of the rule rather than a choice made here: a
+  // recovery that waits is a tool call that hangs, and by the time a person has finished signing in
+  // there is nothing left to recover.
+  const release = deps.capture ? () => {} : await acquireLoginLock();
   if (!release) {
     return {
       attempted: false,

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -27,7 +27,7 @@
 import { AUTH } from "../config.js";
 import { getStore, type StoreSlot, type TokenStore } from "./store.js";
 import { acquireRefreshLock } from "./reflock.js";
-import { StockbitError } from "../http/errors.js";
+import { kindForStatus, StockbitError } from "../http/errors.js";
 import { authenticatedRequest, type RouteName, type TokenDomain } from "../http/transport.js";
 import { logStderr, redact } from "../redact.js";
 import { clearAccessCache, readAccessCache, writeAccessCache } from "./accesscache.js";
@@ -602,8 +602,16 @@ async function refreshOnce(domain: TokenDomain, attempt = 0, locked = false): Pr
     // then say "present and unexpired, but Stockbit rejected it at HH:MM" without spending anything
     // — and a revoked session becomes visible at zero requests instead of only at the next failure.
     recordRefreshFailure(spec.slot, refreshToken, res.status, `HTTP ${res.status}`);
+    // The KIND comes from the status, through the same `kindForStatus` every other HTTP failure in
+    // this project goes through. It used to be the literal `"auth"` on both branches of this
+    // ternary — the ternary picks the MESSAGE — so a 502 from the refresh endpoint was labelled a
+    // credential refusal, and two call sites that branch on `kind === "auth"` read it as one: a
+    // partial outage answered with "your session is dead, log in again", and in `analyze.ts`'s case
+    // rethrown in preference to the real cause. A refusal is 401/403 and nothing else; a 5xx is
+    // `upstream`, a 429 is `rate_limited`, and each of those already has an honest sentence
+    // elsewhere in the stack.
     throw new StockbitError(
-      "auth",
+      kindForStatus(res.status),
       res.status === 401
         ? `Refresh failed (HTTP 401) — the stored ${domain} token is no longer valid. ${spec.rejected}`
         : `Refresh failed (HTTP ${res.status}) for the ${domain} session`,
@@ -929,19 +937,19 @@ function escalate(
   if (err.kind !== "auth") return err;
 
   // And the KIND is not sufficient on its own, which is the part that is easy to miss.
-  // `refreshOnce` labels every non-ok status on the refresh route `auth` — look at its throw: the
-  // ternary chooses the MESSAGE, not the kind — so a 502 from Stockbit's refresh endpoint arrives
-  // here as an auth error. Escalating that would answer a partial outage, which clears by itself,
-  // with "sign your browser out of Stockbit".
+  //
+  // `refreshOnce` used to label every non-ok status on the refresh route `auth`, so a 502 arrived
+  // here looking exactly like a refusal; P7g made it derive the kind from the status through
+  // `kindForStatus`, so it no longer does. This guard is unchanged by that and stays, because it
+  // was never only about the 5xx: `auth` still means "401 or 403", and it is also the kind of every
+  // throw raised with NO status — a credential that is not stored at all. Neither of those is a
+  // credential Stockbit judged and refused, which is the only thing that makes the advice below
+  // true.
   //
   // 401 only, and deliberately not 403. A Cloudflare `cf-mitigated: challenge` answers 403 for a
   // request that — as `challengeError` puts it — never reached Stockbit's handler at all, so no
   // credential was judged. Since the advice this unlocks is destructive, an unobserved 403 is not
   // worth admitting on the chance that it means a refusal.
-  //
-  // (That `refreshOnce` reports a 502 as `auth` at all is a pre-existing inaccuracy — its ternary
-  // picks the message, not the kind. It was harmless while nothing branched on it, and narrowing it
-  // is not this change's to make. This guard makes the escalation independent of it either way.)
   if (err.status !== 401) return err;
 
   // Switched on the OUTCOME, never on the wording. Sniffing `detail` for a prefix would make an

--- a/src/core/brokers.ts
+++ b/src/core/brokers.ts
@@ -7,14 +7,27 @@
  *   GET /order-trade/broker/activity            one broker's stocks; REPEATED market/investor types
  *   GET /order-trade/broker/top                 the league table
  *
- * ## None of these three has been observed live
+ * ## What has been seen, and what has not
  *
- * That is the fact that shapes every projection below. Envelopes are permissive, `data` is accepted
- * as an array or as an object wrapping one, and no row field is renamed on a guess: each row is
- * returned whole under `row`, with the one or two fields this module is willing to claim it
- * recognised sitting beside it and `readFrom` naming the wire key each was read from. A wrong guess
- * therefore shows up as `code: undefined` next to a visible raw row, never as a confident wrong
- * value and never as a key that is always undefined.
+ * All three routes have now answered live. What that settled differs per route, and the difference
+ * is what shapes every projection below.
+ *
+ * `brokerTop`'s ROW SHAPE was measured on 2026-09-01 — ten keys, every figure a plain numeric
+ * string — so its rows ARE projected into named fields. Its two behaviours were measured too, and
+ * both are wrong in a way a caller cannot see from the outside: it sorts ASCENDING by
+ * `total_value`, and it ignores `limit`. `getBrokerTop` fixes both locally and says so in the
+ * result, because a correction the caller cannot see is its own kind of silence.
+ *
+ * `brokerActivity` answered, and its ENVELOPE was measured — `broker_activity_transaction`, `from`,
+ * `to`, `broker_code`, `broker_name` — but the names inside its rows were not recorded. Its
+ * `period` parameter is refused outright; see `buildActivityParams` for the control that settles it.
+ *
+ * Where a shape is still unknown the old discipline holds: envelopes are permissive, `data` is
+ * accepted as an array or as an object wrapping one, and no row field is renamed on a guess. Each
+ * row is returned whole under `row`, with the fields this module is willing to claim it recognised
+ * sitting beside it and `readFrom` naming the wire key each was read from. A wrong guess therefore
+ * shows up as `code: undefined` next to a visible raw row, never as a confident wrong value and
+ * never as a key that is always undefined.
  *
  * `bandar_detector` is the exception: it runs on `getBrokerSummary`, whose response shape was
  * measured, so it projects into named fields with no hedging.
@@ -186,10 +199,28 @@ interface Rowset {
   rows: Row[];
   from: string | null;
   dataKeys: string[];
+  /**
+   * `data` itself, when it was an object.
+   *
+   * These envelopes carry provenance BESIDE the rows — `brokerActivity` puts the window it
+   * aggregated over in `from`/`to`, `brokerTop` puts the session in `date` — and the projection
+   * used to read the array out and drop everything around it. A window the endpoint volunteers and
+   * the tool throws away is a window the caller then has to guess at.
+   */
+  dataObject: Row | null;
 }
 
-/** Envelope keys that plausibly wrap the array, tried in order before falling back to any array. */
+/**
+ * Envelope keys that plausibly wrap the array, tried in order before falling back to any array.
+ *
+ * `broker_activity_transaction` leads because it is the only member here that was MEASURED rather
+ * than guessed: a `brokerActivity` call with no `period` (2026-09-01) answered
+ * `data = {broker_activity_transaction, from, to, broker_code, broker_name}`. The rest remain
+ * plausible names for shapes nobody has seen, and a measured container must win over a guess if a
+ * response ever carries both.
+ */
 const ROW_CONTAINERS = [
+  "broker_activity_transaction",
   "result",
   "results",
   "list",
@@ -207,17 +238,29 @@ const RowArray = z.array(z.record(z.unknown()));
 
 function readRows(body: unknown, context: string): Rowset {
   const { data } = parseOr(Envelope, body, context);
-  if (data === null || data === undefined) return { rows: [], from: null, dataKeys: [] };
+  if (data === null || data === undefined) return { rows: [], from: null, dataKeys: [], dataObject: null };
   if (Array.isArray(data)) {
-    return { rows: parseOr(RowArray, data, `${context} rows`), from: "data", dataKeys: [] };
+    return {
+      rows: parseOr(RowArray, data, `${context} rows`),
+      from: "data",
+      dataKeys: [],
+      // A bare array carries no provenance beside itself. Null, not `{}`: "there was nothing to
+      // read it from" and "it was there and empty" are different answers.
+      dataObject: null,
+    };
   }
   if (typeof data === "object") {
     const obj = data as Row;
     const dataKeys = Object.keys(obj);
     const key =
       ROW_CONTAINERS.find((k) => Array.isArray(obj[k])) ?? dataKeys.find((k) => Array.isArray(obj[k]));
-    if (key === undefined) return { rows: [], from: null, dataKeys };
-    return { rows: parseOr(RowArray, obj[key], `${context} rows`), from: key, dataKeys };
+    if (key === undefined) return { rows: [], from: null, dataKeys, dataObject: obj };
+    return {
+      rows: parseOr(RowArray, obj[key], `${context} rows`),
+      from: key,
+      dataKeys,
+      dataObject: obj,
+    };
   }
   // A scalar under `data` is not a paging edge case; it is a different endpoint answering.
   throw new StockbitError(
@@ -255,6 +298,39 @@ const isCode = (v: string): boolean => BROKER_CODE_RE.test(v);
 const isName = (v: string): boolean => v.length > 0;
 /** Same charset `src/symbol.ts` admits, checked without throwing — this is a guess, not an input. */
 const isSymbolish = (v: string): boolean => /^[A-Z0-9]{1,12}(-[A-Z0-9]{1,4})?$/.test(v);
+
+/**
+ * A number off the broker wire, or `undefined`.
+ *
+ * The same pattern and the same refusals as `asBrokerNumber` in `src/core/marketdetectors.ts`, and
+ * for the same two reasons: a separated number ("1,234" / "1.234,56") is REFUSED rather than
+ * guessed at, because the two Indonesian conventions disagree about which separator is the decimal
+ * one; and E-notation is admitted, because this API sends it.
+ *
+ * It is duplicated rather than imported because that one is not exported and this one reads a
+ * different service's rows — `brokerTop` sends `total_value` as a PLAIN numeric string
+ * (`"5636360451396"`), not the `{raw, formatted}` pair most of this API uses.
+ *
+ * `undefined` on anything else, including on a number that arrived as a JSON number: every figure
+ * measured on these routes is a string, so a bare number is a shape change worth seeing as absent
+ * rather than silently absorbing.
+ */
+const WIRE_NUMBER_RE = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+
+function asWireNumber(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!WIRE_NUMBER_RE.test(trimmed)) return undefined;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/** A non-empty string off the envelope, or `undefined`. Empty means "no value here", not "". */
+function asWireString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
 
 /**
  * How many rows nothing could be read from, plus the keys of the first one.
@@ -513,8 +589,17 @@ export interface BrokerActivityRow {
 
 export interface BrokerActivity {
   brokerCode: string;
-  /** Exactly what went onto the wire, so the window and filters that produced these rows are visible. */
+  /** Exactly what went onto the wire, so the filters that produced these rows are visible. */
   request: Record<string, string | number | readonly string[]>;
+  /**
+   * The window the endpoint says these rows cover, read from `data.from` / `data.to`.
+   *
+   * This route has no period filter (see `buildActivityParams`), so the window is not something a
+   * caller chose — it is something the response announces, and it is the only thing that dates
+   * these figures. Absent when the response did not carry it; never defaulted to today.
+   */
+  from?: string;
+  to?: string;
   count: number;
   rowsFrom: string | null;
   dataKeys: string[];
@@ -524,6 +609,10 @@ export interface BrokerActivity {
 
 export interface BrokerActivityOptions {
   brokerCode: unknown;
+  /**
+   * Refused, always. Present in the options so the refusal can be explicit — see
+   * `buildActivityParams`. Dropping it silently would be worse.
+   */
   period?: unknown;
   /** Boards to include. REPEATED on the wire, one `market_type` per value. */
   marketTypes?: readonly unknown[];
@@ -546,18 +635,45 @@ type WireParams = Record<string, string | number | readonly string[] | undefined
  * repetition on the URL that was actually sent and that no `%2C` appears in it.
  *
  * Every filter is omitted when the caller omits it. Nothing here defaults to a value: a default
- * this project invented would decide the window and the boards on the caller's behalf, and on a
- * route nobody has probed it could equally well be a value the server rejects.
+ * this project invented would decide the boards on the caller's behalf, and on a route nobody has
+ * probed it could equally well be a value the server rejects.
+ *
+ * ## `period` is REFUSED here, and never sent
+ *
+ * Measured on 2026-09-01. This endpoint answers **400 `Your request is invalid`** to `period` —
+ * to every one of the ten `BROKER_PERIODS` members, and to eight other spellings
+ * (`TB_PERIOD_DAILY`, `_1D`, `_ONE_DAY`, `_WEEKLY`, `_MONTHLY`, `DAILY`, `1D`, `daily`). With no
+ * `period` at all it answers **200 with rows**.
+ *
+ * Two controls make that a fact about `period` rather than about the call. `brokerDistribution`
+ * accepts `TB_PERIOD_LAST_1_DAY` on the same vocabulary, so the member is not the problem; and
+ * `tb_period`, `periode`, `range` and `time_period` all answer 200 and are ignored, so this service
+ * SILENTLY DROPS keys it does not know. A 400 therefore means `period` is a recognised field
+ * refusing a value, not an unknown parameter — there is no spelling left to find.
+ *
+ * So it is refused, loudly, rather than dropped on the way to the wire. A dropped filter is worse
+ * than one that errors: the caller reads rows for a window they never asked for and has no way to
+ * see it. `BROKER_PERIODS` is untouched — `brokerDistribution` and `brokerTop` still use it.
+ *
+ * The window is not lost by refusing: this endpoint reports its own in `data.from` / `data.to`,
+ * which `getBrokerActivity` now carries onto the result.
  *
  * Exported so the shape can be asserted without a network round-trip.
  */
 export function buildActivityParams(opts: BrokerActivityOptions): WireParams {
-  const period = opts.period === undefined ? undefined : member(BROKER_PERIODS, opts.period, "period");
+  if (opts.period !== undefined) {
+    throw new StockbitError(
+      "invalid_param",
+      "broker activity has no period filter: this endpoint answers 400 to every value of `period`, " +
+        "including the ones its sibling broker_distribution accepts. Its window is fixed by the " +
+        "server and reported back in `from`/`to` on the result. Omit `period` and read those; use " +
+        "broker_distribution when you need to choose a window.",
+    );
+  }
   const markets = tokenList(BROKER_MARKET_TYPES, opts.marketTypes, "market_type");
   const investors = tokenList(BROKER_INVESTOR_TYPES, opts.investorTypes, "investor_type");
   return {
     broker_code: normalizeBrokerCode(opts.brokerCode),
-    period: period === undefined ? undefined : `TB_PERIOD_${period}`,
     market_type: markets?.map((m) => `MARKET_TYPE_${m}`),
     investor_type: investors?.map((i) => `INVESTOR_TYPE_${i}`),
     sort_by: opts.sortBy === undefined ? undefined : `SORT_BY_${enumToken(opts.sortBy, "sort_by")}`,
@@ -582,9 +698,9 @@ function sent(params: WireParams): Record<string, string | number | readonly str
  * broker and lists stocks. Two calls chain into the question neither answers alone — find today's
  * biggest net seller of a stock, then ask what else that broker was distributing.
  *
- * The cache key is the full parameter set, so a different window, a different board list or a
- * different page is a different entry. Keying on the broker code alone would serve one broker's
- * REGULER week in answer to a question about their ALL-board day.
+ * The cache key is the full parameter set, so a different board list or a different page is a
+ * different entry. Keying on the broker code alone would serve one broker's REGULER answer to a
+ * question about their ALL board.
  */
 export async function getBrokerActivity(opts: BrokerActivityOptions): Promise<BrokerActivity> {
   const params = buildActivityParams(opts);
@@ -592,14 +708,27 @@ export async function getBrokerActivity(opts: BrokerActivityOptions): Promise<Br
 
   return cached(`brokers:activity:${JSON.stringify(request)}`, CACHE.brokerSummaryTtlMs, async () => {
     const body = await getJson("brokerActivity", { params });
-    const { rows, from, dataKeys } = readRows(body, "broker activity");
+    const { rows, from, dataKeys, dataObject } = readRows(body, "broker activity");
     const mapped = rows.map((row) => {
       const symbol = pick(row, SYMBOL_KEYS, isSymbolish);
       return { symbol: symbol.value, readFrom: { symbol: symbol.key }, row };
     });
+    // Beside the rows, not inside them: `data.from` / `data.to` are the window the SERVER chose,
+    // and since `period` is refused they are the only statement of which days these figures are.
+    // Spread, so an envelope that carried neither leaves the keys absent rather than undefined.
+    // Named apart from the destructured `from` above, which is the ENVELOPE KEY the rows came out
+    // of. Two different `from`s in one scope, and confusing them would put a container name where
+    // a date belongs.
+    const windowFrom = asWireString(dataObject?.from);
+    const windowTo = asWireString(dataObject?.to);
+    const window = {
+      ...(windowFrom === undefined ? {} : { from: windowFrom }),
+      ...(windowTo === undefined ? {} : { to: windowTo }),
+    };
     return {
       brokerCode: String(params.broker_code),
       request,
+      ...window,
       count: mapped.length,
       rowsFrom: from,
       dataKeys,
@@ -611,19 +740,92 @@ export async function getBrokerActivity(opts: BrokerActivityOptions): Promise<Br
 
 /* ----------------------------------- top ----------------------------------- */
 
+/**
+ * Which wire key each of `brokerTop`'s figures was read from.
+ *
+ * Wider than `ReadFrom` because this route's row shape IS observed (2026-09-01) and its figures are
+ * therefore projected into named fields rather than left in `row`. A key appears here only when a
+ * value actually came out of it: a `total_value` that would not parse leaves both `totalValue` and
+ * `readFrom.totalValue` absent, so "the wire did not send it" and "this server would not read it"
+ * never look like a figure of zero.
+ */
+export interface BrokerTopReadFrom extends ReadFrom {
+  investorType?: string;
+  totalValue?: string;
+  netValue?: string;
+  buyValue?: string;
+  sellValue?: string;
+  totalVolume?: string;
+  totalFrequency?: string;
+  group?: string;
+}
+
 export interface BrokerTopRow {
   code?: string;
   name?: string;
-  readFrom: ReadFrom;
-  /** The whole row: the value/volume/frequency figures are in here under unobserved names. */
+  /** `investor_type` verbatim — a wire vocabulary this project has not mapped, so it is not renamed. */
+  investorType?: string;
+  /** IDR. The figure the league table is ranked by, and the key the local sort reads. */
+  totalValue?: number;
+  /** IDR. Buys netted against sells. Negative is a net seller; the sign is the wire's. */
+  netValue?: number;
+  buyValue?: number;
+  sellValue?: number;
+  totalVolume?: number;
+  totalFrequency?: number;
+  /** `group` verbatim, e.g. a house's affiliation label. Not mapped, not renamed. */
+  group?: string;
+  readFrom: BrokerTopReadFrom;
+  /** The whole row as it arrived. Nothing is dropped, and a key this projection does not know is here. */
   row: Row;
 }
 
+/**
+ * How the rows got into the order they are in.
+ *
+ * Returned rather than merely documented, because the order is OURS. The endpoint answers
+ * **ascending** by `total_value` (measured across all 89 rows on 2026-09-01: first `22,485,000`,
+ * last `5,636,360,451,396`) and no `sort_by` value reverses it — `sort_by=total_value`,
+ * `sort_by=TOTAL_VALUE`, `order_by=desc` and `sort_direction=DESC` are all accepted with a 200 and
+ * all leave the order alone, while `order=desc` and `sort=desc` answer 400. So a descending league
+ * table can only be produced here, and a re-sort the caller cannot see would be exactly the kind of
+ * silent behaviour this module exists to refuse.
+ */
+export interface BrokerTopSort {
+  /** The row key the sort read. Always `total_value`: it is the only ranking the route publishes. */
+  by: "total_value";
+  direction: "descending";
+  /** True always, and stated anyway — the caller must not read this order as the exchange's. */
+  appliedLocally: true;
+  /**
+   * Rows whose `total_value` could not be read. They keep their wire order and sit AFTER every
+   * sorted row, because a row with no rank cannot be given one.
+   */
+  unsortable: number;
+}
+
+/** The session this table covers, from `data.date`. Absent keys stay absent. */
+export interface BrokerTopDate {
+  from?: string;
+  to?: string;
+  /** Stockbit's own index-date field. Passed through under its wire name; its meaning is unmapped. */
+  idx?: string;
+}
+
 export interface BrokerTop {
+  /** Exactly what went onto the wire. `limit` is NOT in here — see `getBrokerTop`. */
   request: Record<string, string | number | readonly string[]>;
+  /** Provenance the response volunteered: which session these figures are. Absent if it did not. */
+  date?: BrokerTopDate;
+  /** Rows in `brokers` — after the local `limit`, when one was given. */
   count: number;
+  /** Rows the response actually carried. Equal to `count` when no `limit` was applied. */
+  countBeforeLimit: number;
+  /** Present only when `limit` was passed. The cap is OURS: the endpoint ignores its own. */
+  limitAppliedLocally?: number;
   rowsFrom: string | null;
   dataKeys: string[];
+  sortedLocally: BrokerTopSort;
   brokers: BrokerTopRow[];
   unmapped: Unmapped;
 }
@@ -632,7 +834,36 @@ export interface BrokerTopOptions {
   period?: unknown;
   sortBy?: unknown;
   page?: unknown;
+  /**
+   * Rows to keep. Applied HERE, after the descending sort, because the endpoint ignores it: at
+   * `limit=3` and at `limit=5` it returned the same 89 rows (2026-09-01).
+   */
   limit?: unknown;
+}
+
+/** Read one measured numeric key, naming it only when a number actually came out of it. */
+function figure(row: Row, key: string): { value?: number; key?: string } {
+  const value = asWireNumber(row[key]);
+  return value === undefined ? {} : { value, key };
+}
+
+/** The same for a measured string key. */
+function label(row: Row, key: string): { value?: string; key?: string } {
+  const value = asWireString(row[key]);
+  return value === undefined ? {} : { value, key };
+}
+
+/** `data.date` — three strings, each absent rather than empty when the wire sent nothing. */
+function readTopDate(raw: Row): BrokerTopDate | undefined {
+  const from = asWireString(raw.from);
+  const to = asWireString(raw.to);
+  const idx = asWireString(raw.idx);
+  if (from === undefined && to === undefined && idx === undefined) return undefined;
+  return {
+    ...(from === undefined ? {} : { from }),
+    ...(to === undefined ? {} : { to }),
+    ...(idx === undefined ? {} : { idx }),
+  };
 }
 
 /**
@@ -642,34 +873,122 @@ export interface BrokerTopOptions {
  * parameters are documented for the activity route and only for it, so they are not sent here —
  * a filter this endpoint ignores would silently widen the answer, and one it rejects would 400 a
  * call that had no need to carry it.
+ *
+ * ## Two things this function does that the endpoint does not
+ *
+ * **It sorts.** Descending by `total_value`, locally. See `BrokerTopSort` for what was measured.
+ * A tool whose whole description is "which brokers moved the most" was putting the biggest broker
+ * last, and the ignored `limit` was the only thing hiding it.
+ *
+ * **It applies `limit`.** Also locally, and `limit` is NOT sent: the endpoint ignores it, and a
+ * parameter on the wire that changes nothing reads back through `request` as a cap the server
+ * honoured. Refusing it outright was the alternative, but a league table is exactly the shape a
+ * caller wants the top of, and `limitAppliedLocally` says whose cap it is.
+ *
+ * Because `limit` is not on the wire it is not in the cache key either — which is the point. The
+ * FULL sorted table is what is cached, and the trim happens on a copy, so asking for the top 3 and
+ * then the top 10 is one fetch. Same shape, and the same trap, as `getBrokerDirectory`'s `codes`:
+ * trimming the cached object in place would hand every later caller this caller's cap.
  */
 export async function getBrokerTop(opts: BrokerTopOptions = {}): Promise<BrokerTop> {
   const period = opts.period === undefined ? undefined : member(BROKER_PERIODS, opts.period, "period");
+  // Validated before the fetch, so a mistyped cap is an error here rather than a silent full table.
+  const limit = opts.limit === undefined ? undefined : pageNumber(opts.limit, "limit");
   const params: WireParams = {
     period: period === undefined ? undefined : `TB_PERIOD_${period}`,
     sort_by: opts.sortBy === undefined ? undefined : `SORT_BY_${enumToken(opts.sortBy, "sort_by")}`,
     page: opts.page === undefined ? undefined : pageNumber(opts.page, "page"),
-    limit: opts.limit === undefined ? undefined : pageNumber(opts.limit, "limit"),
   };
   const request = sent(params);
 
-  return cached(`brokers:top:${JSON.stringify(request)}`, CACHE.brokerSummaryTtlMs, async () => {
+  const full = await cached(`brokers:top:${JSON.stringify(request)}`, CACHE.brokerSummaryTtlMs, async () => {
     const body = await getJson("brokerTop", { params });
-    const { rows, from, dataKeys } = readRows(body, "top brokers");
-    const brokers = rows.map((row) => {
+    const { rows, from, dataKeys, dataObject } = readRows(body, "top brokers");
+    const mapped = rows.map((row) => {
       const code = pick(row, CODE_KEYS, isCode);
       const name = pick(row, NAME_KEYS, isName);
-      return { code: code.value, name: name.value, readFrom: { code: code.key, name: name.key }, row };
+      // These eight are read by their MEASURED key, not from a candidate list: the row shape was
+      // observed on 2026-09-01 and each figure is a plain numeric string ("-15025000"), not the
+      // `{raw, formatted}` pair most of this API sends. A candidate list here would be pretending
+      // not to know something that was measured.
+      const investorType = label(row, "investor_type");
+      const group = label(row, "group");
+      const totalValue = figure(row, "total_value");
+      const netValue = figure(row, "net_value");
+      const buyValue = figure(row, "buy_value");
+      const sellValue = figure(row, "sell_value");
+      const totalVolume = figure(row, "total_volume");
+      const totalFrequency = figure(row, "total_frequency");
+      return {
+        code: code.value,
+        name: name.value,
+        investorType: investorType.value,
+        totalValue: totalValue.value,
+        netValue: netValue.value,
+        buyValue: buyValue.value,
+        sellValue: sellValue.value,
+        totalVolume: totalVolume.value,
+        totalFrequency: totalFrequency.value,
+        group: group.value,
+        readFrom: {
+          code: code.key,
+          name: name.key,
+          investorType: investorType.key,
+          totalValue: totalValue.key,
+          netValue: netValue.key,
+          buyValue: buyValue.key,
+          sellValue: sellValue.key,
+          totalVolume: totalVolume.key,
+          totalFrequency: totalFrequency.key,
+          group: group.key,
+        },
+        row,
+      };
     });
-    return {
+    // Counted BEFORE the sort: `unmappedOf` walks `rows` and `mapped` in parallel, so it has to see
+    // them in the same order. Sorting first would report another row's keys as the unreadable one's.
+    const unmapped = unmappedOf(rows, mapped, "code");
+
+    // Partition, then sort — rather than one comparator that pushes undefined to the end. A row
+    // with no readable `total_value` has no rank, and giving it one (top or bottom, by comparator
+    // accident) is inventing a position. These keep wire order and sit after everything ranked.
+    const ranked = mapped.filter((b) => b.totalValue !== undefined);
+    const unranked = mapped.filter((b) => b.totalValue === undefined);
+    // Node's sort is stable, so brokers tied on value stay in the order the exchange sent them.
+    ranked.sort((a, b) => (b.totalValue as number) - (a.totalValue as number));
+    const brokers = [...ranked, ...unranked];
+
+    const rawDate = dataObject?.date;
+    const date =
+      typeof rawDate === "object" && rawDate !== null && !Array.isArray(rawDate)
+        ? readTopDate(rawDate as Row)
+        : undefined;
+
+    const result: BrokerTop = {
       request,
+      ...(date === undefined ? {} : { date }),
       count: brokers.length,
+      countBeforeLimit: brokers.length,
       rowsFrom: from,
       dataKeys,
+      sortedLocally: {
+        by: "total_value",
+        direction: "descending",
+        appliedLocally: true,
+        unsortable: unranked.length,
+      },
       brokers,
-      unmapped: unmappedOf(rows, brokers, "code"),
+      unmapped,
     };
+    return result;
   });
+
+  if (limit === undefined) return full;
+
+  // A NEW object. `full` is the shared cache entry, and slicing its `brokers` in place would hand
+  // every later caller of that entry this caller's cap.
+  const brokers = full.brokers.slice(0, limit);
+  return { ...full, count: brokers.length, brokers, limitAppliedLocally: limit };
 }
 
 /* ------------------------------ bandar detector ------------------------------ */

--- a/src/core/company.ts
+++ b/src/core/company.ts
@@ -501,6 +501,14 @@ async function readShareholdersChart(
     // written down anywhere in this repo. A gateway that answered the same rpc error under some
     // other status would slip past a kind-only test and hand the caller back the raw string —
     // which is the exact dead end this whole branch exists to remove.
+    //
+    // Still the kind, and still not the status, after P7g made `refreshOnce` derive its kind from
+    // the status. That change removed the one wrong match this branch could make — a 502 while
+    // refreshing the session mid-call used to arrive labelled `auth` and be explained as "the
+    // shareholder chart refused its minted token", which is a confident answer to a question nobody
+    // asked. What it does not do is give this branch a status to narrow on: the failure it is FOR
+    // has no recorded status at all, as the paragraph above says, so a status test would put the
+    // whole diagnosis behind a number nobody has written down.
     if (error instanceof StockbitError && (error.kind === "auth" || WEBVIEW_TOKEN_REFUSAL.test(error.message))) {
       throw new StockbitError(
         "auth",

--- a/src/core/corpaction.ts
+++ b/src/core/corpaction.ts
@@ -54,6 +54,9 @@ export interface RowSet {
    * Where the rows were found:
    *   `data`            — `data` was itself the array
    *   `data.<key>`      — the array was nested one level down (the watchlist detail does this)
+   *   `data.{a,b}`      — SEVERAL arrays, one per kind: the day calendar's bucket shape, and these
+   *                       are the buckets that actually contributed rows. `data.{}` is every bucket
+   *                       present and empty, which is a real, empty day. See `bucketsOf`.
    *   `absent`          — the response carried no `data` at all. NOT the same as an empty list.
    *   `unrecognized`    — `data` was present but was not a row list; see `raw`, which is then the
    *                       only trustworthy answer, and treat `rows: []` as "not parsed", not "none".
@@ -76,6 +79,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * as the array with pagination beside it — and anything else is reported as `unrecognized` rather
  * than flattened to an empty list. That distinction is the point: an empty array from the server and
  * a shape this function could not read are the same value and must not be the same answer.
+ *
+ * Note the FIRST array wins, which is only safe because these routes carry one. The day calendar
+ * carries twelve, and reading it with this function bound to whichever kind sorted first; `bucketsOf`
+ * is the reader for that shape and runs ahead of this one on that one route.
  */
 function rowsOf(data: unknown): RowSet {
   if (data === undefined || data === null) return { rows: [], rowsFrom: "absent" };
@@ -471,9 +478,129 @@ export async function getDividendCalendar(symbol?: string, limit?: number): Prom
 
 /* --------------------------------- the day calendar --------------------------------- */
 
+/**
+ * One row of the day calendar, tagged with the bucket it was found in.
+ *
+ * `corpactionType` is added by this tool, not by Stockbit — the same convention and the same field
+ * name `getDividendCalendar` uses when it merges two kinds into one list. A second spelling for the
+ * same idea is how two readers of this server's output come to disagree about which field says what
+ * kind a row is.
+ *
+ * The value is the bucket key EXACTLY as the response spelled it, never translated, and it is a
+ * plain string rather than a `CorpactionType` for a measured reason: two of the twelve buckets seen
+ * on 2026-09-01 are not the spellings the `/corpaction/{actionType}` path takes. The calendar says
+ * `stock_reverse` and `tender` where `CORPACTION_TYPES` says `reversesplit` and `tenderoffer`.
+ * Passing one of those two straight into `corporate_actions` is therefore refused as an unknown
+ * kind — which is the right outcome, because nothing here has verified that the two vocabularies
+ * name the same thing, and rewriting `tender` to `tenderoffer` would be that claim made silently.
+ */
+export interface CalendarRow extends Record<string, unknown> {
+  corpactionType: string;
+}
+
 export interface CalendarDay extends RowSet {
-  /** The date requested, or null when none was sent and the server chose its own "today". */
+  /**
+   * The day these rows are for, `YYYY-MM-DD` — the date requested, or the `today` the response
+   * itself carried when none was sent.
+   *
+   * The server's own value is used because it is the only thing here that knows what day it is in
+   * WIB: the process clock is UTC and the two disagree for the first seven hours of every day, so a
+   * substituted local "today" would be a confident wrong date. Null means no date was requested AND
+   * the response carried no `today` this code could read as one; the raw value, if there was one, is
+   * still in `meta`.
+   */
   date: string | null;
+  /**
+   * Where `date` came from — the request, or the response's own `today`. Absent exactly when `date`
+   * is null, so it is never a claim about a value that is not there.
+   *
+   * Whether `today` echoes the date that was ASKED for or names the server's current day is not
+   * known: the only live call was undated. So it is read as a fallback and never as a check on
+   * whether a dated request was honoured — a check that fired on every legitimate past-date request
+   * would teach a reader to ignore it. `meta.today` carries the raw value beside the requested date
+   * either way, so anyone who needs to compare the two still can.
+   */
+  dateFrom?: "request" | "data.today";
+  /**
+   * Every bucket the response carried, with how many rows were in it — ZEROS INCLUDED.
+   *
+   * This is what separates the two readings of a kind that is not in `rows`. A kind listed here with
+   * 0 was returned by Stockbit and is empty for this day. A kind NOT listed was not in the response
+   * at all, and nothing here says whether that means empty or unsupported. The field being absent
+   * altogether means the response was not the bucket shape, so no row carries `corpactionType`.
+   */
+  buckets?: Record<string, number>;
+}
+
+/**
+ * The day calendar's BUCKET shape: one key per action kind, each holding that kind's rows.
+ *
+ * Measured live on 2026-09-01: `GET /corpaction` answered with twelve such keys — `bonus`,
+ * `dividend`, `economic`, `ipo`, `pubex`, `rightissue`, `rups`, `stock_reverse`, `stocksplit`,
+ * `stock_dividend`, `tender`, `warrant` — beside a `today` string. Every kind is present every day
+ * and most of them are empty, which is what made this worth its own reader: `rowsOf` binds to the
+ * FIRST array it finds, `bonus` comes first and was empty, so the calendar reported `rows: []` with
+ * `rowsFrom: "data.bonus"` while nineteen dividend, RUPS, warrant and economic rows sat unread in
+ * `meta`. An empty answer is bad. An empty answer that claims to have parsed the payload is worse,
+ * because `rowsFrom` is precisely what a reader consults to tell "none today" from "not parsed".
+ *
+ * Detection is STRUCTURAL — two or more array-of-record values — and never a match against
+ * `CORPACTION_TYPES`. One array beside its siblings is the nested shape `rowsOf` already reads (rows
+ * under a key, pagination next to them) and is left to it. A bucket whose name this module does not
+ * recognise is still a bucket full of real rows, and dropping it is the defect being fixed here; the
+ * two spellings that already differ from the path vocabulary are the standing proof that a
+ * name-matched reader would have thrown rows away.
+ *
+ * `economic` is kept in the SAME list as the rest, deliberately. An economic event is not a
+ * corporate action — it is a data release and it belongs to no issuer — but this codebase already
+ * treats it as one kind among the twelve: `economic` is in `CORPACTION_TYPES`,
+ * `/corpaction/economic` is how `corporate_actions` fetches it, and that tool's own description
+ * names it. Splitting it out only here would be a second convention for a distinction the rest of
+ * the module does not make, and would drop eight rows the server sent out of a list whose whole
+ * purpose is "what is happening today". Its rows are tagged `corpactionType: "economic"` like every
+ * other bucket, so a caller who wants corporate actions alone filters that one value out, and
+ * `buckets.economic` gives the count to subtract without walking the rows.
+ */
+function bucketsOf(
+  data: unknown,
+): (RowSet & { rows: CalendarRow[]; buckets: Record<string, number> }) | null {
+  if (!isRecord(data)) return null;
+  const buckets = Object.entries(data).filter(
+    (entry): entry is [string, Array<Record<string, unknown>>] =>
+      Array.isArray(entry[1]) && entry[1].every(isRecord),
+  );
+  if (buckets.length < 2) return null;
+
+  const names = new Set(buckets.map(([kind]) => kind));
+  const meta = Object.fromEntries(Object.entries(data).filter(([key]) => !names.has(key)));
+  const filled = buckets.filter(([, bucket]) => bucket.length > 0).map(([kind]) => kind);
+  return {
+    // The tag is spread LAST, so it always describes the bucket the row was actually found in, the
+    // same way `getDividendCalendar` adds `corpactionType` last for the same reason.
+    rows: buckets.flatMap(([kind, bucket]) => bucket.map((row): CalendarRow => ({ ...row, corpactionType: kind }))),
+    // Several places, so it names them all — the buckets that CONTRIBUTED, in wire order. Naming one
+    // of twelve would imply the other eleven were read and empty, which is the lie this whole reader
+    // exists to stop.
+    rowsFrom: `data.{${filled.join(",")}}`,
+    buckets: Object.fromEntries(buckets.map(([kind, bucket]) => [kind, bucket.length])),
+    ...(Object.keys(meta).length > 0 ? { meta } : {}),
+  };
+}
+
+/**
+ * The `today` a calendar response carries, normalized to `YYYY-MM-DD`, or null.
+ *
+ * Deliberately stricter than `asDate`: only the dashed and compact forms are taken, and the
+ * `Date.parse` fallback under them is not. This value becomes the `date` a caller reads as the day
+ * the rows describe, and `Date.parse("01/09/2026")` is the 9th of January — a confident wrong day is
+ * worse here than no day at all, which is the same bargain absent-is-not-zero makes everywhere else.
+ * A value this refuses is still in `meta.today`, unaltered, for a reader who can make sense of it.
+ */
+function serverToday(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (!/^\d{4}-\d{2}-\d{2}/.test(text) && !/^(?:19|20)\d{6}$/.test(text)) return null;
+  return asDate(text);
 }
 
 /**
@@ -486,10 +613,23 @@ export interface CalendarDay extends RowSet {
  */
 export async function getCalendarDay(date?: string): Promise<CalendarDay> {
   const day = date === undefined ? undefined : normalizeTradeDate(date);
-  return cached(`corpaction:day:${day ?? "server-default"}`, CACHE.keystatsTtlMs, async () => ({
-    date: day ?? null,
-    ...(await fetchRows("corpactionToday", "corporate action calendar", { params: { date: day } })),
-  }));
+  return cached(`corpaction:day:${day ?? "server-default"}`, CACHE.keystatsTtlMs, async () => {
+    const body = await getJson("corpactionToday", { params: { date: day } });
+    const data = parseOr(Envelope, body, "corporate action calendar").data;
+    // Buckets first, `rowsOf` behind it. Not a replacement: this endpoint has only ever been
+    // measured undated, and a day that came back as one flat list must still be read as one.
+    const set = bucketsOf(data) ?? rowsOf(data);
+    // Read off `data` itself rather than off `set.meta`, so it works on both shapes — `rowsOf`
+    // returns no `meta` at all when `data` is a bare array.
+    const served = isRecord(data) ? serverToday(data.today) : null;
+    const from: CalendarDay["dateFrom"] =
+      day !== undefined ? "request" : served !== null ? "data.today" : undefined;
+    return {
+      date: day ?? served,
+      ...(from ? { dateFrom: from } : {}),
+      ...set,
+    };
+  });
 }
 
 /** The most days one `calendar_range` call will fetch. One request per day, so this is 31 requests. */

--- a/src/core/market.ts
+++ b/src/core/market.ts
@@ -30,8 +30,10 @@ import { cached, parseOr, wireNumber } from "./_util.js";
 import { CACHE } from "../config.js";
 import { normalizeSymbol } from "../symbol.js";
 import { normalizeTradeDate, todayIso } from "./dates.js";
+import { readRaw } from "../live/tape.js";
 import type { Bar } from "./bars.js";
-import type { QueryParams, RouteName } from "../http/transport.js";
+import { MARKET_MOVER_VIEWS, MARKET_MOVER_WIRE } from "../http/transport.js";
+import type { MarketMoverView, QueryParams, RouteName } from "../http/transport.js";
 
 /**
  * The one thing every response here has in common: a `data` block whose contents vary.
@@ -431,13 +433,33 @@ export async function getSeriesBars(symbol: string, timeframe: string): Promise<
 }
 
 /**
- * The chart route's payload, unprojected.
+ * The chart payload `getSeriesBars` reads, unprojected.
  *
- * The sibling of the route `getSeriesBars` reads, and the one to reach for when a projected series
- * comes back with a non-empty `unmapped` or `extraKeys`: it returns exactly what Stockbit sends, so
- * the real field spellings can be read off it and `POINT_KEYS` corrected. It is not a fallback for
- * `getSeriesBars` and is never called automatically — a silent second attempt against a different
- * route would make "which endpoint answered" unknowable.
+ * The escape hatch for when a projected series comes back with a non-empty `unmapped` or
+ * `extraKeys`: it returns exactly what Stockbit sends, so the real field spellings can be read off
+ * it and `POINT_KEYS` corrected.
+ *
+ * ## It used to read a DIFFERENT ROUTE from the one it exists to diagnose
+ *
+ * This called `charts` (`/charts/:symbol`) while `getSeriesBars` calls `chartsDaily`
+ * (`/charts/:symbol/daily`) — two different endpoints — and handed the first the second's timeframe
+ * vocabulary. The two do not share one, measured 2026-09-01:
+ *
+ *   - `/charts/:symbol/daily` accepts `1w`, `1m`, `1d`, `3m`, `ytd`, `1y` and answers the rich
+ *     payload the projection reads: `prices`, `cagr`, `change`, `drawdown`, `markingpoint`, …
+ *   - `/charts/:symbol` REFUSES `1w` with 400 `Kurun waktu tidak valid`, accepts the rest, and
+ *     answers `{chart_points: []}` — a different, near-empty container.
+ *
+ * So `1w` came back 400 and `1m` came back empty, and both were the route being wrong rather than
+ * the value. A diagnostic tool that cannot reproduce the payload it is meant to diagnose is the
+ * worst version of this bug, because the caller reads the empty result as "the drift is gone".
+ *
+ * It now reads the same route, with the same parameters, as the projection it explains. That is the
+ * whole point of it: `raw: true` must differ from the projected call in exactly one way — that
+ * nothing is projected.
+ *
+ * It is still not a fallback for `getSeriesBars` and is still never called automatically; a silent
+ * second attempt would make "which endpoint answered" unknowable.
  */
 export async function getChartRaw(symbol: string, timeframe: string): Promise<unknown> {
   const sym = normalizeSymbol(symbol);
@@ -445,7 +467,7 @@ export async function getChartRaw(symbol: string, timeframe: string): Promise<un
   return cached(`chartRaw:${sym}:${tf}`, CACHE.brokerSummaryTtlMs, () => {
     const params: QueryParams = { timeframe: tf };
     if (NEEDS_PREVIOUS_HISTORICAL.includes(tf)) params.is_include_previous_historical = true;
-    return readData("charts", "chart", { segments: { symbol: sym }, params });
+    return readData("chartsDaily", "chart", { segments: { symbol: sym }, params });
   });
 }
 
@@ -745,19 +767,283 @@ export async function getTradeBook(opts: TradeBookOptions = {}): Promise<unknown
 /* ============================== movers & top stocks ============================== */
 
 /**
- * The order-trade service's own market movers.
- *
- * Not the same endpoint as `top_movers` in `src/core/emitten.ts`, which reads the hotlist, and the
- * two are not guaranteed to agree — a caller comparing them is comparing two services, not
- * validating one. No filter is sent beyond `limit`: this endpoint's category vocabulary has not been
- * observed, and a guessed one would narrow the answer silently.
+ * Keys of a `mover_list` row this projection reads. Anything outside this set lands in
+ * `unmappedKeys`, which is the diagnostic that survives a schema change: if Stockbit renames a
+ * field, the new name appears there and the fix is one line rather than another live probe.
  */
-export async function getMarketMovers(limit?: number): Promise<unknown> {
+const MOVER_ROW_KEYS = new Set([
+  "stock_detail",
+  "price",
+  "change",
+  "value",
+  "volume",
+  "frequency",
+  "net_foreign_buy",
+  "net_foreign_sell",
+  "net_buy",
+  "net_sell",
+  "iepiev_detail",
+  "big_money_net_value",
+  "buy_value_percentage",
+  "sell_value_percentage",
+  "big_money_buy_value_percentage",
+  "big_money_sell_value_percentage",
+  "bid_percent",
+  "catalog_detail",
+  "market_cap",
+]);
+
+/** One row of `data.mover_list`, projected. Absent means the wire did not carry it — never zero. */
+export interface MarketMoverRow {
+  symbol?: string;
+  name?: string;
+  price?: number;
+  change?: number;
+  changePercent?: number;
+  /** Traded value in RUPIAH. Not lots, not shares. */
+  value?: number;
+  /** Traded volume. Unit as the service reports it — see `readFrom.volume` for the wire key. */
+  volume?: number;
+  /** Number of transactions. */
+  frequency?: number;
+  netForeignBuy?: number;
+  netForeignSell?: number;
+  netBuy?: number;
+  netSell?: number;
+  bigMoneyNetValue?: number;
+  /**
+   * The pre-opening indicative equilibrium price and volume, when there is one.
+   *
+   * This is the UI's eighth movers tab, and it is a FIELD rather than a view — every attempt to
+   * request it as a `mover_type` was refused. It is only meaningful during pre-opening
+   * (08:45-09:00 WIB); outside that window the service returns zeros, which is why every member
+   * here is optional and a zero is passed through as the zero it is rather than dropped.
+   */
+  iepIev?: {
+    iep?: number;
+    iev?: number;
+    ieval?: number;
+    iepChange?: number;
+    iepChangePrev?: number;
+    iepPriceDiff?: number;
+    iepPrevPriceDiff?: number;
+  };
+  readFrom: Record<string, string>;
+  /** Keys on this row that this projection does not recognise. */
+  unmappedKeys: string[];
+  /** The row exactly as it arrived. Nothing dropped, nothing renamed on a guess. */
+  row: Record<string, unknown>;
+}
+
+export interface MarketMoversResult {
+  /**
+   * The view the server says it served, read from its ECHO — never from what was requested.
+   *
+   * The distinction is the whole reason this endpoint can be trusted: it echoes `mover_type` back,
+   * and it 400s on a member it does not know, so the echo is a statement about what was served.
+   */
+  view: string | null;
+  /** The friendly name that was requested, or null when none was sent. */
+  requested: string | null;
+  rows: MarketMoverRow[];
+  count: number;
+  /** Envelope key the rows were read from; null when the response carried no array. */
+  rowsFrom: string | null;
+  /** What `data` carried when it was an object. Only interesting when `rowsFrom` is null. */
+  dataKeys: string[];
+  /**
+   * Which session the foreign-flow figures on these rows are from, as the payload states it.
+   *
+   * `isShowNetForeign` is the service's own signal for whether those figures mean anything yet: it
+   * was observed FALSE intraday and TRUE after the ~18:00 WIB broker release on the same day, which
+   * is what settled that the foreign data is not stale, merely unpublished until then.
+   */
+  foreign: {
+    isShown: boolean | null;
+    updatedAt: string | null;
+    sessionDate: string | null;
+    isLastSession: boolean | null;
+    sessionLabel: string | null;
+  };
+  /** How `limit` was actually treated, because the answer is not the obvious one. See below. */
+  limitNote: string;
+}
+
+const num = (v: unknown): number | undefined => {
+  const n = readRaw(v);
+  return n === null ? undefined : n;
+};
+
+/** Read the `iepiev_detail` block, or nothing at all if it is absent. */
+function readIepIev(v: unknown): MarketMoverRow["iepIev"] {
+  if (!v || typeof v !== "object") return undefined;
+  const o = v as Record<string, unknown>;
+  const out = {
+    iep: num(o.iep),
+    iev: num(o.iev),
+    ieval: num(o.ieval),
+    iepChange: num(o.iep_change),
+    iepChangePrev: num(o.iep_change_prev),
+    iepPriceDiff: num(o.iep_price_diff),
+    iepPrevPriceDiff: num(o.iep_prev_price_diff),
+  };
+  return Object.values(out).some((x) => x !== undefined) ? out : undefined;
+}
+
+function projectMoverRow(row: Record<string, unknown>): MarketMoverRow {
+  const detail = (row.stock_detail ?? {}) as Record<string, unknown>;
+  const change = (row.change ?? {}) as Record<string, unknown>;
+
+  const symbol = typeof detail.code === "string" && detail.code.length > 0 ? detail.code : undefined;
+  const name = typeof detail.name === "string" && detail.name.length > 0 ? detail.name : undefined;
+
+  const readFrom: Record<string, string> = {};
+  const note = (field: string, key: string, value: unknown): void => {
+    if (value !== undefined) readFrom[field] = key;
+  };
+
+  const price = num(row.price);
+  const changeValue = num(change.value);
+  const changePercent = num(change.percentage);
+  const value = num(row.value);
+  const volume = num(row.volume);
+  const frequency = num(row.frequency);
+  const netForeignBuy = num(row.net_foreign_buy);
+  const netForeignSell = num(row.net_foreign_sell);
+  const netBuy = num(row.net_buy);
+  const netSell = num(row.net_sell);
+  const bigMoneyNetValue = num(row.big_money_net_value);
+  const iepIev = readIepIev(row.iepiev_detail);
+
+  note("symbol", "stock_detail.code", symbol);
+  note("name", "stock_detail.name", name);
+  note("price", "price", price);
+  note("change", "change.value", changeValue);
+  note("changePercent", "change.percentage", changePercent);
+  note("value", "value", value);
+  note("volume", "volume", volume);
+  note("frequency", "frequency", frequency);
+  note("netForeignBuy", "net_foreign_buy", netForeignBuy);
+  note("netForeignSell", "net_foreign_sell", netForeignSell);
+  note("netBuy", "net_buy", netBuy);
+  note("netSell", "net_sell", netSell);
+  note("bigMoneyNetValue", "big_money_net_value", bigMoneyNetValue);
+  note("iepIev", "iepiev_detail", iepIev);
+
+  return {
+    symbol,
+    name,
+    price,
+    change: changeValue,
+    changePercent,
+    value,
+    volume,
+    frequency,
+    netForeignBuy,
+    netForeignSell,
+    netBuy,
+    netSell,
+    bigMoneyNetValue,
+    iepIev,
+    readFrom,
+    unmappedKeys: Object.keys(row).filter((k) => !MOVER_ROW_KEYS.has(k)),
+    row,
+  };
+}
+
+/** Read a `{raw, formatted, date, is_last_session}` session block without inventing any of it. */
+function readSessionInfo(v: unknown): { date: string | null; label: string | null; isLast: boolean | null } {
+  if (!v || typeof v !== "object") return { date: null, label: null, isLast: null };
+  const o = v as Record<string, unknown>;
+  return {
+    date: typeof o.date === "string" ? o.date : null,
+    label: typeof o.formatted === "string" ? o.formatted : null,
+    isLast: typeof o.is_last_session === "boolean" ? o.is_last_session : null,
+  };
+}
+
+export interface MarketMoversOptions {
+  /** A `MARKET_MOVER_WIRE` friendly name. Omitted takes whatever the server's default view is. */
+  view?: MarketMoverView;
+  limit?: number;
+}
+
+/**
+ * The order-trade service's own market movers — the endpoint behind Stockbit's Movers dialog.
+ *
+ * Not the same endpoint as `top_movers` in `src/core/emitten.ts`, which reads the hotlist. The two
+ * are not guaranteed to agree and a caller comparing them is comparing two services rather than
+ * validating one. That is not a hedge: measured on 2026-09-01 the hotlist served **nine** symbols
+ * while this endpoint served **fifty**, including structured warrants. They have different
+ * universes, so a symbol in one and not the other is expected.
+ *
+ * ## The view vocabulary is closed, and the echo is why it can be trusted
+ *
+ * Eight members are settled (see `MARKET_MOVER_WIRE`), each echoed back verbatim, against a control
+ * that 400s. The echo is read back onto `view`, so the caller is told what was SERVED rather than
+ * what was asked for — those differ on any endpoint that silently falls back, and this one is only
+ * known not to for the members listed.
+ *
+ * ## `limit`, and the pagination block that is furniture
+ *
+ * `limit` IS honoured: 5 gives 5. But 100 gives 50, so 50 is a ceiling the service applies on top.
+ * `page` and `per_page` are IGNORED — `page=1` returns the same rows as no page at all.
+ *
+ * And `data.pagination` is dead: it came back `{page: 0, limit: 0, has_next: false, has_prev: false}`
+ * on every single call regardless of what was sent, including calls that returned a truncated 5 of
+ * 50. It is therefore NOT projected. A `has_next: false` that is always false is not an answer about
+ * whether more rows exist, and passing it through would be inventing one.
+ */
+export async function getMarketMovers(opts: MarketMoversOptions = {}): Promise<MarketMoversResult> {
   const params: QueryParams = {};
-  if (limit !== undefined) params.limit = positiveInt("limit", limit);
-  return cached(keyFor("marketMover", params), CACHE.defaultTtlMs, () =>
-    readData("marketMover", "market mover", { params }),
-  );
+  if (opts.view !== undefined) {
+    const wire = MARKET_MOVER_WIRE[opts.view];
+    // Not a defensive nicety: an unlisted member is a 400 from this endpoint, and refusing locally
+    // says which members exist instead of spending a round trip to be told the request was invalid.
+    if (wire === undefined) {
+      throw new StockbitError(
+        "invalid_param",
+        `view must be one of ${MARKET_MOVER_VIEWS.join(", ")} — got ${String(opts.view)}. The UI's ` +
+          "IEP/IEV tab is deliberately absent: it is not a view this endpoint accepts, and its " +
+          "figures arrive on every row as iepIev instead.",
+      );
+    }
+    params.mover_type = wire;
+  }
+  if (opts.limit !== undefined) params.limit = positiveInt("limit", opts.limit);
+
+  return cached(keyFor("marketMover", params), CACHE.defaultTtlMs, async () => {
+    const data = (await readData("marketMover", "market mover", { params })) as
+      | Record<string, unknown>
+      | null;
+    const obj = data && typeof data === "object" ? data : {};
+    const list = obj.mover_list;
+    const rows = Array.isArray(list) ? (list as Record<string, unknown>[]) : [];
+    const session = readSessionInfo(obj.net_foreign_session_info);
+
+    return {
+      // The echo. Never `opts.view`.
+      view: typeof obj.mover_type === "string" ? obj.mover_type : null,
+      requested: opts.view ?? null,
+      rows: rows.map(projectMoverRow),
+      count: rows.length,
+      rowsFrom: Array.isArray(list) ? "mover_list" : null,
+      dataKeys: Object.keys(obj),
+      foreign: {
+        isShown: typeof obj.is_show_net_foreign === "boolean" ? obj.is_show_net_foreign : null,
+        updatedAt: typeof obj.net_foreign_updated_at === "string" ? obj.net_foreign_updated_at : null,
+        sessionDate: session.date,
+        isLastSession: session.isLast,
+        sessionLabel: session.label,
+      },
+      limitNote:
+        opts.limit === undefined
+          ? "No limit sent; the service returned its default page (50 rows when measured)."
+          : `limit=${opts.limit} was sent and this endpoint honours it, but it caps the result at 50 ` +
+            "rows however large the limit. page and per_page are ignored, and the payload's own " +
+            "pagination block reads all zeros on every call, so it is not reported.",
+    } satisfies MarketMoversResult;
+  });
 }
 
 /** The order-trade service's top-stock list. Same caveats as `getMarketMovers`. */
@@ -811,8 +1097,9 @@ export async function getMarketSession(): Promise<unknown> {
 
 /* ================================= batch prices ================================= */
 
-/** Our own ceiling on one batch, to keep a query string from growing without bound. */
-export const PRICES_BATCH_MAX = 50;
+// `PRICES_BATCH_MAX` used to live here — our own 50-symbol ceiling on a batch. It is gone because
+// the batch is gone: this route takes one `stock_code`, so a ceiling on a list it does not accept
+// would only describe a shape no caller can reach. See `getPricesBatch`.
 
 export interface PricesBatch {
   /** What was asked for, normalized and de-duplicated. */
@@ -824,8 +1111,39 @@ export interface PricesBatch {
   rows: Array<Record<string, unknown>>;
   /** Where the rows were located, or `null` when the response held no row array at all. */
   dataPath: string | null;
-  /** The `data` block verbatim when no rows could be located, so nothing is lost. */
+  /**
+   * The price series, when the payload carried bare NUMBERS rather than records.
+   *
+   * This is what the route actually returned when measured on 2026-09-01: `data.prices` held 20
+   * bare numbers for one symbol. `locateRows` looks for arrays of RECORDS and correctly declines to
+   * bind an array of numbers, so without this field the result was `rows: []` with `dataPath: null`
+   * — indistinguishable from "this symbol has no prices", which is a claim about the market made
+   * out of a projection mismatch.
+   *
+   * `null` means no numeric series was found, which is different from an empty one.
+   */
+  series: number[] | null;
+  /** Where the series was located, e.g. `data.prices`. Null when there was none. */
+  seriesPath: string | null;
+  /** The `data` block verbatim when neither rows nor a series could be located, so nothing is lost. */
   raw?: unknown;
+}
+
+/**
+ * Find an array of bare numbers in the payload, one level under `data`.
+ *
+ * Deliberately narrow: it looks for a numeric array, not for anything array-shaped, so it cannot
+ * quietly claim a row array as a series. Returns the key it bound to, because "which field was
+ * this" is the diagnostic that makes a schema change one line to fix.
+ */
+function locateSeries(data: unknown): { path: string; values: number[] } | null {
+  if (!data || typeof data !== "object") return null;
+  for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+    if (!Array.isArray(value) || value.length === 0) continue;
+    const nums = value.map((v) => readRaw(v));
+    if (nums.every((n): n is number => n !== null)) return { path: `data.${key}`, values: nums };
+  }
+  return null;
 }
 
 /**
@@ -846,36 +1164,70 @@ function symbolsIn(row: Record<string, unknown>, requested: readonly string[]): 
 }
 
 /**
- * Last price for several symbols in one request.
+ * Last price for ONE symbol. The "batch" in the name is a premise this route does not support.
  *
- * The multi-value encoding is the open question. `stock_code` is singular, so the symbols are sent
- * comma-joined; if the endpoint in fact wants a repeated key it will read only the first and answer
- * 200 with one row, exactly the silent narrowing that `brokerActivity` was bitten by.
+ * ## The encoding question is closed, and the answer is that there is no encoding
  *
- * That is why the result reports `found` and `missing` instead of just rows. A wrong encoding then
- * shows up as "asked for six, one found, five missing" — a loud, correct description of what
- * happened — rather than as a short list nobody questions. `missing` is not proof a symbol has no
- * price; it means no returned row mentioned it.
+ * The `found`/`missing` reporting below was built to diagnose a suspected encoding bug, and it did
+ * its job: it said "asked for three, found none" rather than returning an empty list that reads as
+ * "no prices". Measured 2026-09-01, every encoding was tried and the route is simply not a batch:
+ *
+ *   - `stock_code=BBRI` → 200, `data.prices` = an array of **20 bare numbers** — a price SERIES for
+ *     that one symbol, not one last price per symbol
+ *   - `stock_code=BBRI,BBCA,TLKM` → 200, `data.prices` = **empty**
+ *   - `stock_code=BBRI&stock_code=BBCA` (repeated key, the encoding the field report proposed) →
+ *     **400 `too many values for field "stock_code"`**. Explicitly refused, so it is not the answer
+ *   - `stock_code[]=…` → the same 400
+ *   - `symbols=…` → 400 `Silahkan Periksa permintaan`
+ *   - `stock_code=BBRI|BBCA|TLKM` → 200, empty
+ *
+ * A comma-joined list is read as one invalid code and answers empty; a repeated key is a hard 400.
+ * There is no third option left to try. `/company-price-feed/prices` takes one `stock_code`.
+ *
+ * So this refuses more than one symbol locally rather than sending a request that has been measured
+ * to come back empty. Returning an empty batch here would be the exact failure this repo's notes
+ * call worse than an error: it reads as "these symbols have no prices", which is a claim about the
+ * market rather than about the request.
  */
 export async function getPricesBatch(symbols: readonly string[]): Promise<PricesBatch> {
   if (!Array.isArray(symbols) || symbols.length === 0) {
     throw new StockbitError("invalid_param", "At least one symbol is required");
   }
   const requested = [...new Set(symbols.map((s) => normalizeSymbol(s)))];
-  if (requested.length > PRICES_BATCH_MAX) {
+  if (requested.length > 1) {
     throw new StockbitError(
       "invalid_param",
-      `Too many symbols (${requested.length}); this client sends at most ${PRICES_BATCH_MAX} per ` +
-        "request. Split the list and call again.",
+      `This route takes ONE symbol, and ${requested.length} were given. Measured 2026-09-01: ` +
+        "comma-joining them returns an empty list, and the repeated-key form answers 400 " +
+        '"too many values for field stock_code", so there is no encoding that batches. Call it ' +
+        "once per symbol, or use quote for a single last price. It returns a price SERIES for the " +
+        "one symbol, not a last price.",
     );
   }
 
-  const params: QueryParams = { stock_code: requested.join(",") };
+  const params: QueryParams = { stock_code: requested[0] };
   return cached(keyFor("pricesBatch", params), CACHE.quoteTtlMs, async () => {
     const data = await readData("pricesBatch", "batch prices", { params });
     const located = locateRows(data);
+    // Checked whether or not rows were found: the measured payload is a numeric series, and a
+    // result that reported only `rows: []` for it would read as "no prices" for a symbol whose
+    // prices were right there.
+    const series = locateSeries(data);
+
     if (!located) {
-      return { requested, found: [], missing: [...requested], rows: [], dataPath: null, raw: data };
+      return {
+        requested,
+        // A numeric series carries no ticker to match, so `found` cannot be filled from it. The
+        // symbol is nonetheless answered-for: exactly one was requested and the route echoed a
+        // series for it, which is why `missing` is empty when a series came back.
+        found: series ? [...requested] : [],
+        missing: series ? [] : [...requested],
+        rows: [],
+        dataPath: null,
+        series: series?.values ?? null,
+        seriesPath: series?.path ?? null,
+        raw: data,
+      };
     }
     const found = [...new Set(located.rows.flatMap((row) => symbolsIn(row, requested)))];
     return {
@@ -884,6 +1236,8 @@ export async function getPricesBatch(symbols: readonly string[]): Promise<Prices
       missing: requested.filter((s) => !found.includes(s)),
       rows: located.rows,
       dataPath: located.path,
+      series: series?.values ?? null,
+      seriesPath: series?.path ?? null,
     };
   });
 }
@@ -904,33 +1258,33 @@ export interface MarketPricesOptions {
 /**
  * One symbol's prices broken down by market board, for a session.
  *
- * Board values are sent **unprefixed**. This repo already carries two prefixed board vocabularies
- * that disagree with each other — `MARKET_BOARD_` on broker summary, `MARKET_TYPE_` on broker
- * distribution, and sending one endpoint's spelling to the other 400s — so inventing a third prefix
- * here would be guessing twice over. The caller's value goes out as written, uppercased.
+ * ## This endpoint cannot be called. It is not a vocabulary problem.
+ *
+ * Measured 2026-09-01: `/company-price-feed/prices/BBRI/market` answers **400
+ * `Silahkan Periksa permintaan` with no query parameters at all** — a bare call, nothing to be
+ * wrong about. It also refuses every board spelling tried (`REGULER`, `RG`, `regular`, `REGULAR`,
+ * `TN`, `NG`, `CASH`, `ALL`, `MARKET_TYPE_REGULAR`, `MARKET_TYPE_ALL`, `BOARD_REGULAR`, `1`, `0`)
+ * under every key tried (`market`, `board`, `market_type`, `type`).
+ *
+ * A bare call being refused is what settles it: if no arguments is also an error, then no argument
+ * combination can be the fix. Earlier passes read the 400s as "the board vocabulary is unknown" and
+ * kept probing spellings; the missing control was the empty request.
+ *
+ * **The workaround exists and returns the same information.** `orderbook`'s `market_data[]` already
+ * carries the per-board split (All Market / Regular / Nego / Cash) for a symbol.
+ *
+ * This therefore refuses locally and names the alternative, rather than offering arguments for a
+ * call that cannot succeed. A tool that cannot be called should say so — spending a round trip to
+ * be told the request is invalid teaches the caller nothing this comment does not.
  */
 export async function getMarketPrices(opts: MarketPricesOptions): Promise<unknown> {
-  const sym = normalizeSymbol(opts.symbol);
-  const params: QueryParams = {};
-  const date = opts.date === undefined ? undefined : normalizeTradeDate(opts.date, "date");
-  if (date !== undefined) params.date = date;
-  if (opts.boards !== undefined && opts.boards.length > 0) {
-    params.boards = opts.boards.map((b) => {
-      const board = String(b).trim().toUpperCase();
-      if (!BOARD_RE.test(board)) {
-        throw new StockbitError(
-          "invalid_param",
-          `Invalid market board ${JSON.stringify(b)}: expected an uppercase name such as REGULER, ` +
-            "NEGO or TUNAI",
-        );
-      }
-      return board;
-    });
-  }
-  // A session that closed before today can no longer change; only a request touching today needs a
-  // short lifetime. Same split `src/core/brokerdistribution.ts` makes for a settled date range.
-  const ttl = date !== undefined && date < todayIso() ? CACHE.keystatsTtlMs : CACHE.quoteTtlMs;
-  return cached(`${keyFor("pricesMarket", params)}:${sym}`, ttl, () =>
-    readData("pricesMarket", "market prices", { segments: { symbol: sym }, params }),
+  throw new StockbitError(
+    "upstream",
+    "price_market cannot be called: /company-price-feed/prices/:symbol/market answers 400 " +
+      '"Silahkan Periksa permintaan" with NO parameters at all, and with every board spelling and ' +
+      "parameter name tried (measured 2026-09-01). Since a bare request is also refused, no " +
+      "argument combination fixes it. Use orderbook instead — its market_data[] already returns " +
+      "the per-board split (All Market / Regular / Nego / Cash) for a symbol.",
   );
 }
+

--- a/src/core/pricefeed.ts
+++ b/src/core/pricefeed.ts
@@ -199,10 +199,35 @@ export interface PriceBands {
   /** The band for the NEXT session, where Stockbit publishes it. */
   nextAra: number | null;
   nextArb: number | null;
-  /** Foreign buy / sell / net for the session, in the units the payload uses. */
+  /**
+   * Foreign buy / sell / net for the session, in RUPIAH — the units the payload uses.
+   *
+   * **Which session these are from is NOT on this payload.** See `dataAsOf`, and read it before
+   * treating these as today's.
+   */
   foreignBuy: number | null;
   foreignSell: number | null;
   foreignNet: number | null;
+  /**
+   * Which trading session the foreign figures above belong to — and it is deliberately `null`.
+   *
+   * This payload does not carry a date. That is the finding, not an omission here: the orderbook
+   * response has no field naming the session its `fbuy`/`fsell`/`fnet` came from, so anything put
+   * here would be invented.
+   *
+   * It matters because foreign flow across this API publishes at roughly **18:00 WIB**. Before that
+   * release these figures are the PREVIOUS session's, and nothing on this payload says so. The
+   * sharpest form of the problem: `technicals` has been seen reporting `netForeignIdr: 0` for today
+   * while `orderbook` reported −12.2B, and neither payload lets a caller adjudicate.
+   *
+   * **The date is not fetched from elsewhere on purpose.** `market_movers` does carry it
+   * (`foreign.sessionDate`, `foreign.isShown`), but reaching for a second endpoint to fill this in
+   * would couple two routes and attribute one's date to the other's numbers — which is inventing a
+   * date with extra steps. `noteAsOf` says where to look instead.
+   */
+  dataAsOf: string | null;
+  /** Why `dataAsOf` is null, and where the answer actually lives. */
+  noteAsOf: string;
   /** Field names that were present in the response. */
   found: string[];
   /** Field names that were looked for and were not there. */
@@ -243,6 +268,17 @@ export function extractBands(symbol: string, payload: unknown): PriceBands {
     foreignBuy: out.foreignBuy,
     foreignSell: out.foreignSell,
     foreignNet: out.foreignNet,
+    // Always null, and always for the same reason: this payload carries no date. Stated as a field
+    // rather than left to the caller to notice, because the figures above are unusable without it
+    // and their absence of provenance is invisible otherwise.
+    dataAsOf: null,
+    noteAsOf:
+      "This payload carries no session date, so the foreign figures above cannot be attributed to " +
+      "a day from this response alone. Foreign flow publishes at roughly 18:00 WIB: before that " +
+      "release these are the PREVIOUS session's. market_movers carries the date explicitly as " +
+      "foreign.sessionDate, with foreign.isShown flagging whether the current session's figures " +
+      "have published yet. It is not read from there automatically — attributing one endpoint's " +
+      "date to another's numbers would be inventing it.",
     found,
     missing,
   };

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -53,7 +53,24 @@ interface GatewayEnvelope {
   errors?: Array<{ key?: string; error?: string }>;
 }
 
-function kindForStatus(status: number): ErrorKind {
+/**
+ * The mapping from an HTTP status to an `ErrorKind`. One definition, and it is this one.
+ *
+ * Exported because it was private and a second copy grew: `refreshOnce` in `src/auth/session.ts`
+ * labelled every non-ok refresh response `auth` — its ternary picked the message, not the kind —
+ * so a 502 from Stockbit's refresh endpoint was indistinguishable from a revoked credential, and
+ * both `analysis/analyze.ts` and `core/company.ts` branch on `kind === "auth"`. A partial outage
+ * therefore reported itself as a dead session and offered to sign the user out of their browser to
+ * fix it. The fix is not a second table with 502 added to it; it is this one, used by both.
+ *
+ * Note what a kind does NOT say. `auth` means "the status was 401 or 403" — a refusal — and says
+ * nothing about WHICH credential was refused or whether one was even presented: `challenge` (a
+ * Cloudflare 403 that never reached Stockbit's handler) and the several `StockbitError("auth", …)`
+ * throws raised with no status at all, for a credential that is simply not stored, are both `auth`
+ * and neither came from here. A caller that needs "Stockbit refused the credential I sent" must
+ * still read `status`, which is why two guards deliberately do.
+ */
+export function kindForStatus(status: number): ErrorKind {
   if (status === 400) return "invalid_param";
   if (status === 401 || status === 403) return "auth";
   if (status === 404) return "not_found";

--- a/src/http/transport.ts
+++ b/src/http/transport.ts
@@ -88,6 +88,46 @@ export const MOVER_WIRE = {
 export type MoverTypeName = keyof typeof MOVER_WIRE;
 
 /**
+ * The `market-mover` service's OWN view vocabulary. A different endpoint from `MOVER_WIRE` above,
+ * and a different spelling system — protobuf enum members rather than lowercase path segments.
+ *
+ * **Every member here was echoed back by the server on 2026-09-01.** That is the whole standard for
+ * this table, and it is a stronger one than it looks, because of the control:
+ * `MOVER_TYPE_DEFINITELY_NOT_REAL` answers **400 `Your request is invalid`**. So this endpoint
+ * REJECTS unknown members rather than silently serving its default — which is the failure mode that
+ * hid the `topGainer`/`topgainer` bug in `MOVER_WIRE` for months, and it is absent here. An echo
+ * that matches what was sent is therefore evidence of acceptance, not merely of a 200.
+ *
+ * Fifteen further spellings were refused and are deliberately NOT listed as members. The ones worth
+ * knowing about, so nobody re-guesses them: `MOVER_TYPE_TOP_GAINERS` and `_TOP_LOSERS` (plural),
+ * `MOVER_TYPE_TOP_FREQ`, `MOVER_TYPE_FOREIGN_BUY` and `_FOREIGN_SELL` (without `NET_`).
+ *
+ * **The UI's IEP/IEV tab is not here, and must not be added.** Ten spellings of it were refused
+ * (`MOVER_TYPE_IEP_IEV`, `_IEPIEV`, `_IEV`, `_IEP`, `_IEP_IEV_DETAIL`, `_INDICATIVE`,
+ * `_INDICATIVE_EQUILIBRIUM`, `_PRE_OPENING`, `_PREOPENING`, `_IEP_CHANGE`, `_TOP_IEP`). It is not a
+ * view at all: `iepiev_detail` rides on every row of every view, so that tab is served by reading a
+ * field. See `getMarketMovers`.
+ *
+ * Keeping the friendly name in the tool schema and the wire member here is the same bargain
+ * `MOVER_WIRE` makes, for the same reason: exactly one place for the two to disagree.
+ */
+export const MARKET_MOVER_WIRE = {
+  topGainer: "MOVER_TYPE_TOP_GAINER",
+  topLoser: "MOVER_TYPE_TOP_LOSER",
+  topValue: "MOVER_TYPE_TOP_VALUE",
+  topVolume: "MOVER_TYPE_TOP_VOLUME",
+  topFrequency: "MOVER_TYPE_TOP_FREQUENCY",
+  netForeignBuy: "MOVER_TYPE_NET_FOREIGN_BUY",
+  netForeignSell: "MOVER_TYPE_NET_FOREIGN_SELL",
+  bigMoneyNetValue: "MOVER_TYPE_BIG_MONEY_NET_VALUE",
+} as const;
+
+export type MarketMoverView = keyof typeof MARKET_MOVER_WIRE;
+
+/** The friendly names, for a tool schema's enum. Ordered as the UI's own dialog orders its tabs. */
+export const MARKET_MOVER_VIEWS = Object.keys(MARKET_MOVER_WIRE) as MarketMoverView[];
+
+/**
  * The corporate-action kinds that appear as a path segment.
  *
  * A closed table for the same reason `MOVER_WIRE` is one: these go into the URL, and Stockbit

--- a/src/tools/brokers.ts
+++ b/src/tools/brokers.ts
@@ -2,10 +2,15 @@
  * The broker family's tools: the code->name directory, one broker's stocks, the league table, and a
  * typed accumulation/distribution reading.
  *
- * Three of the four run on routes nobody has observed live, so their descriptions say which parts
- * of the output are projected and which are raw. That sentence is not decoration: these tools are
- * read by a model that has no other documentation, and a projected field it trusts blindly is worse
- * than one it knows to check.
+ * Every description here says which parts of the output are projected and which are raw. That is
+ * not decoration: these tools are read by a model that has no other documentation, and a projected
+ * field it trusts blindly is worse than one it knows to check.
+ *
+ * Two of them now say something more awkward, and have to. `broker_top` REFUSES the order the
+ * exchange sent and the `limit` the caller asked for — it sorts and trims locally, because the
+ * endpoint sorts ascending and ignores `limit` — and `broker_activity` REFUSES `period`, because
+ * every value of it is a 400 there. A correction a caller cannot see is its own kind of silence,
+ * so each is stated in the description AND carried in the result.
  */
 import { z } from "zod";
 import * as brokers from "../core/brokers.js";
@@ -71,29 +76,42 @@ export function registerBrokerTools(define: Definer): void {
       "of a stock from broker_summary, then ask here what else that broker was distributing.\n" +
       "`broker_code` is the two-letter code (YP, CC, XL); use the `brokers` tool to find one by " +
       "name. An unknown or malformed code is rejected before any request goes out.\n" +
+      "NO WINDOW TO CHOOSE. This endpoint has no period filter: measured on 2026-09-01, every " +
+      "value of `period` answers 400 — including LAST_1_DAY, which its sibling broker_distribution " +
+      "accepts on the same vocabulary — while sending none returns rows. Passing `period` here is " +
+      "REFUSED with that explanation rather than dropped on the way out, because a filter you " +
+      "asked for and silently did not get is worse than one that errors. The window is the " +
+      "server's and it announces it: read `from` and `to` on the result, which is where these rows " +
+      "are dated. Use broker_distribution when you need to choose the window yourself.\n" +
       "FILTERS: `market_types` and `investor_types` each take a LIST, and each value is sent as its " +
       "own repeated parameter. Passing several boards means the union of those boards. Omit a " +
       "filter and it is not sent at all, in which case the server picks the default and this tool " +
-      "cannot tell you which one it picked — pass `period` if the window matters to your answer. " +
-      "REGULER is the ordinary order book and what bandarmology normally means; ALL folds in " +
-      "negotiated block trades and can be several times larger.\n" +
-      "`request` in the result echoes exactly what was sent, so the window and filters behind the " +
-      "rows are always visible.\n" +
-      "PENDING VERIFICATION: this route has not been observed live. Only the traded `symbol` is " +
-      "projected, with `readFrom.symbol` naming the key it came from; the value, volume and " +
-      "frequency figures are left inside the raw `row` under their own names rather than renamed on " +
-      "a guess, because a net figure read out of the wrong key would point confidently the wrong " +
-      "way. Read them from `row`.\n" +
+      "cannot tell you which one it picked. REGULER is the ordinary order book and what " +
+      "bandarmology normally means; ALL folds in negotiated block trades and can be several times " +
+      "larger.\n" +
+      "`request` in the result echoes exactly what was sent, so the filters behind the rows are " +
+      "always visible.\n" +
+      "The route HAS answered live and its envelope is known, but the names inside its ROWS have " +
+      "not been recorded. So only the traded `symbol` is projected, with `readFrom.symbol` naming " +
+      "the key it came from; the value, volume and frequency figures are left inside the raw `row` " +
+      "under their own names rather than renamed on a guess, because a net figure read out of the " +
+      "wrong key would point confidently the wrong way. Read them from `row`.\n" +
       "`rowsFrom: null` with `count: 0` means the response carried no array — an empty result or an " +
       "unrecognised shape, distinguished by `dataKeys` — and NOT a broker who traded nothing.",
     {
       broker_code: z.string().describe("Broker code, 2-4 uppercase letters or digits, e.g. YP"),
+      // Still ACCEPTED by the schema, and then refused — deliberately. Dropping the key from the
+      // shape would make the SDK strip it, and the caller would read rows for a window they asked
+      // to change and never learn the ask went nowhere. A plain string rather than the enum so
+      // every spelling of the mistake reaches the refusal that explains it, instead of half of
+      // them bouncing off a zod enum error that explains nothing.
       period: z
-        .enum(brokers.BROKER_PERIODS)
+        .string()
         .optional()
         .describe(
-          "Window to aggregate over, e.g. LAST_1_DAY, LAST_7_DAYS, YEAR_TO_DATE. Omitted means " +
-            "the server's own default, which this tool cannot report.",
+          "NOT ACCEPTED — this endpoint answers 400 to every value of it, so passing it is " +
+            "refused here with an explanation. The window is fixed by the server and reported " +
+            "back in `from`/`to`. Use broker_distribution to choose a window.",
         ),
       market_types: z
         .array(z.enum(brokers.BROKER_MARKET_TYPES))
@@ -134,13 +152,28 @@ export function registerBrokerTools(define: Definer): void {
       "than one. Use it to pick a broker worth asking broker_activity about.\n" +
       "This is a market-level ranking, not a per-stock one — a broker at the top of it is not " +
       "thereby active in any particular stock. For a single stock use broker_summary.\n" +
+      "THE ORDER IS THIS SERVER'S, NOT THE EXCHANGE'S. The endpoint answers ASCENDING by " +
+      "`total_value` — biggest broker LAST — and no sort argument reverses it: `sort_by`, " +
+      "`order_by` and `sort_direction` are accepted and change nothing, `order` and `sort` are " +
+      "refused with a 400. So the rows are re-sorted here, DESCENDING by `total_value`, and " +
+      "`sortedLocally` on the result says so. `sortedLocally.unsortable` counts rows whose " +
+      "`total_value` could not be read; they keep their wire order at the END, because a row with " +
+      "no rank is not given one.\n" +
+      "`limit` IS ALSO THIS SERVER'S. The endpoint ignores it — the same 89 rows come back at " +
+      "limit=3 and limit=5 — so the cap is applied here, after the sort, and `limitAppliedLocally` " +
+      "names it while `countBeforeLimit` says how many rows there were before the trim. Do not " +
+      "read a short list as the exchange's answer to your `limit`.\n" +
       "Board and investor-class filters are deliberately NOT offered here: they are documented for " +
       "the broker_activity route and only for it, and a filter this endpoint quietly ignores would " +
       "widen the answer without saying so. Use broker_activity when you need them.\n" +
-      "Each entry carries `code` and " +
-      "`name` where a recognised key held them, `readFrom` naming those keys, and the whole raw " +
-      "row under `row` — the value, volume and frequency figures are in there under names that " +
-      "have not been confirmed, so read them from `row`.\n" +
+      "Each entry carries `code`, `name`, `investorType` and `group` as sent, the figures " +
+      "`totalValue`, `netValue`, `buyValue`, `sellValue`, `totalVolume` and `totalFrequency` as " +
+      "numbers, `readFrom` naming the wire key each was read from, and the whole raw row under " +
+      "`row`. Values are IDR and volumes are LOTS, as everywhere in this family. A figure that was " +
+      "not sent, or that this server would not parse, is ABSENT together with its `readFrom` " +
+      "entry — never zero.\n" +
+      "`date` carries the session the table covers (`from`, `to`, `idx`) when the response " +
+      "volunteered it, which is the only thing dating these figures.\n" +
       "`rowsFrom: null` with `count: 0` means no array was found in the response, not an empty " +
       "market; `dataKeys` shows what the response did carry.",
     {
@@ -153,10 +186,20 @@ export function registerBrokerTools(define: Definer): void {
         .optional()
         .describe(
           `Sort key without the SORT_BY_ prefix. Known values: ${brokers.BROKER_SORT_KEYS.join(", ")}. ` +
-            "The list is partial, so any uppercase token is accepted.",
+            "The list is partial, so any uppercase token is accepted. It does NOT decide the order " +
+            "you get back: no value of it was seen to change the endpoint's ordering, and the rows " +
+            "are sorted here descending by total_value regardless. It is sent, and echoed in " +
+            "`request`, in case it selects something other than order.",
         ),
       page: z.coerce.number().optional().describe("1-based page. Omitted means the server default."),
-      limit: z.coerce.number().optional().describe("Rows per page. Omitted means the server default."),
+      limit: z
+        .coerce.number()
+        .optional()
+        .describe(
+          "Rows to keep. Applied HERE after the descending sort, because the endpoint ignores its " +
+            "own limit; it is not sent. `limitAppliedLocally` echoes it and `countBeforeLimit` " +
+            "says what it trimmed.",
+        ),
     },
     async (a) =>
       runTool(() =>

--- a/src/tools/brokers.ts
+++ b/src/tools/brokers.ts
@@ -169,9 +169,13 @@ export function registerBrokerTools(define: Definer): void {
       "Each entry carries `code`, `name`, `investorType` and `group` as sent, the figures " +
       "`totalValue`, `netValue`, `buyValue`, `sellValue`, `totalVolume` and `totalFrequency` as " +
       "numbers, `readFrom` naming the wire key each was read from, and the whole raw row under " +
-      "`row`. Values are IDR and volumes are LOTS, as everywhere in this family. A figure that was " +
-      "not sent, or that this server would not parse, is ABSENT together with its `readFrom` " +
-      "entry — never zero.\n" +
+      "`row`. UNITS ARE NOT ESTABLISHED FOR THIS ROUTE. The value figures are consistent with " +
+      "rupiah by their magnitude (the largest broker on the 2026-09-01 reading was 5,636,360,451,396), " +
+      "but `totalVolume`'s unit was never sampled and nothing here has confirmed whether it is lots " +
+      "or shares. Elsewhere in this API that distinction is a factor of 100 and it is genuinely " +
+      "mixed — `orderbook.volume` is SHARES while `technicals.volumeLots` is LOTS — so do not " +
+      "assume this one matches either without checking. A figure that was not sent, or that this " +
+      "server would not parse, is ABSENT together with its `readFrom` entry — never zero.\n" +
       "`date` carries the session the table covers (`from`, `to`, `idx`) when the response " +
       "volunteered it, which is the only thing dating these figures.\n" +
       "`rowsFrom: null` with `count: 0` means no array was found in the response, not an empty " +

--- a/src/tools/corpaction.ts
+++ b/src/tools/corpaction.ts
@@ -126,8 +126,22 @@ export function registerCorpactionTools(define: Definer): void {
       "release, not a corporate action and not tied to an issuer — filter `corpactionType` on it, " +
       "or subtract `buckets.economic`, when you need corporate actions alone.\n" +
       "`date` is the day requested, or the `today` the response itself carried when none was sent, " +
-      "and `dateFrom` says which. Null `date` with no `dateFrom` means neither was available.\n" +
-      "An empty day is normal: weekends, holidays, and plenty of ordinary sessions have no actions.",
+      "and `dateFrom` says which. Null `date` with no `dateFrom` means no usable day was available " +
+      "— either none was sent and the response carried none, or it carried one this server would " +
+      "not parse, in which case the raw value is still in `meta.today`. Check there before " +
+      "concluding the server said nothing about the date.\n" +
+      "BEFORE REPORTING AN EMPTY DAY, CHECK WHICH KIND OF EMPTY IT IS. `rowsFrom: \"absent\"` or " +
+      "`\"unrecognized\"` with `rows: []` and NO `buckets` key means the payload was NOT PARSED — " +
+      "not that nothing is happening. Only `rows: []` alongside a populated `buckets` (every kind " +
+      "listed, all zero) is a genuinely quiet day. Reporting the first as the second is the exact " +
+      "defect this tool was fixed for: it reported a market-wide day of 19 corporate actions as " +
+      "none, because it bound to an empty bucket and never said it had failed to read the rest.\n" +
+      "The bucketed shape above was read off ONE live call, and that call sent no arguments. The " +
+      "`date` and `from`/`to` forms have not been measured, so if a dated call comes back as a " +
+      "flat list you will get rows with no `corpactionType` and no `buckets` — read `rowsFrom` " +
+      "rather than assuming the bucketed shape.\n" +
+      "An empty day is otherwise normal: weekends, holidays, and plenty of ordinary sessions have " +
+      "no actions.",
     {
       date: z.string().optional().describe("One day, YYYY-MM-DD. Omit for the server's today"),
       from: z.string().optional().describe("Range start, YYYY-MM-DD. Requires `to`"),
@@ -148,13 +162,25 @@ export function registerCorpactionTools(define: Definer): void {
           ? core.getCalendarRange({ from: a.from, to: a.to })
           : core.getCalendarDay(a.date as string | undefined);
       }),
-    // Settled by a live call on 2026-09-01: `GET /corpaction` answered from a real account, and the
-    // twelve bucket keys and the `today` string this tool names were read out of that response —
-    // which is also how the bucket shape came to light, after the reader had been binding to the
-    // empty `bonus` bucket and reporting a market-wide day of 19 actions as none. The DATED form of
-    // the same route was not measured separately, and both shapes are still read: a day that comes
-    // back as one flat list is reported with the `rowsFrom` it has always had.
-    { evidence: "observed" },
+    // PROJECTED, deliberately, and it was `observed` for a few hours before this comment replaced
+    // that claim.
+    //
+    // What WAS measured, live on 2026-09-01: `GET /corpaction` with NO arguments answered from a
+    // real account, and the twelve bucket keys and the `today` string this tool names were read out
+    // of that response. That call is also what exposed the defect — the reader had been binding to
+    // the empty `bonus` bucket and reporting a market-wide day of 19 actions as none.
+    //
+    // What was NOT measured is the rest of this tool's surface: `date`, and `from`/`to`, which
+    // `getCalendarRange` issues as one DATED request per day. Whether the dated form also returns
+    // buckets is unknown, and the code keeps a flat-shape branch whose output has neither
+    // `corpactionType` nor `buckets`.
+    //
+    // This repo has already settled how to grade that. `shareholding` was fixed and verified on one
+    // mode and STAYED `projected` because its other three were unprobed — `docs/PENDING-
+    // VERIFICATION.md` says so in as many words. One call form out of three is the same situation,
+    // and `observed` here would tell a caller the shape was seen live for a request nobody has
+    // sent. One live `GET /corpaction?date=<a past trading day>` settles it.
+    { evidence: "projected" },
   );
 
   define.read(

--- a/src/tools/corpaction.ts
+++ b/src/tools/corpaction.ts
@@ -111,8 +111,23 @@ export function registerCorpactionTools(define: Definer): void {
       "`date` alone for one specific day, or `from` and `to` together for a range. `from` without " +
       "`to` is rejected rather than sent, because a half-specified window is exactly the input this " +
       "endpoint answers with the wrong day. Mixing `date` with `from`/`to` is also rejected.\n" +
-      "An empty day is normal: weekends, holidays, and plenty of ordinary sessions have no actions. " +
-      UNVERIFIED,
+      "The response is BUCKETED, one key per action kind, and all of them are returned. Every row " +
+      "carries `corpactionType` naming the bucket it came from — added by this tool, not by " +
+      "Stockbit, and spelled exactly as the response spelled it. Two of those spellings are NOT the " +
+      "`action_type` vocabulary: the calendar says `stock_reverse` and `tender` where " +
+      "`corporate_actions` takes `reversesplit` and `tenderoffer`, and neither is translated here " +
+      "because nothing has verified they name the same thing.\n" +
+      "`buckets` lists every kind the response carried with its row count, zeros included. That is " +
+      "the difference between a kind that came back EMPTY today and one that was not in the " +
+      "response at all: the first is in `buckets` with 0, the second is missing from it. `rowsFrom` " +
+      "names the buckets that actually contributed rows (`data.{dividend,rups}`), so " +
+      "`data.{}` with a populated `buckets` is a genuinely empty day rather than an unread payload.\n" +
+      "`economic` is one of the buckets and its rows ARE in the list. An economic event is a data " +
+      "release, not a corporate action and not tied to an issuer — filter `corpactionType` on it, " +
+      "or subtract `buckets.economic`, when you need corporate actions alone.\n" +
+      "`date` is the day requested, or the `today` the response itself carried when none was sent, " +
+      "and `dateFrom` says which. Null `date` with no `dateFrom` means neither was available.\n" +
+      "An empty day is normal: weekends, holidays, and plenty of ordinary sessions have no actions.",
     {
       date: z.string().optional().describe("One day, YYYY-MM-DD. Omit for the server's today"),
       from: z.string().optional().describe("Range start, YYYY-MM-DD. Requires `to`"),
@@ -133,6 +148,13 @@ export function registerCorpactionTools(define: Definer): void {
           ? core.getCalendarRange({ from: a.from, to: a.to })
           : core.getCalendarDay(a.date as string | undefined);
       }),
+    // Settled by a live call on 2026-09-01: `GET /corpaction` answered from a real account, and the
+    // twelve bucket keys and the `today` string this tool names were read out of that response —
+    // which is also how the bucket shape came to light, after the reader had been binding to the
+    // empty `bonus` bucket and reporting a market-wide day of 19 actions as none. The DATED form of
+    // the same route was not measured separately, and both shapes are still read: a day that comes
+    // back as one flat list is reported with the `rowsFrom` it has always had.
+    { evidence: "observed" },
   );
 
   define.read(

--- a/src/tools/market.ts
+++ b/src/tools/market.ts
@@ -330,7 +330,8 @@ export function registerMarketTools(define: Definer): void {
       "orderbook depth use quote or orderbook. For several symbols, call this once per symbol.\n" +
       "`missing` still does not prove a symbol has no price: it means no returned row mentioned " +
       "that ticker. Symbols are matched against the rows' own string values rather than a named " +
-      "field, because the key the ticker lives under has not been observed.",
+      "field — that ONE detail, which key the ticker sits under, is still unsettled, while the " +
+      "route's own behaviour above was measured live.",
     {
       symbols: z
         .array(z.string())

--- a/src/tools/market.ts
+++ b/src/tools/market.ts
@@ -9,6 +9,8 @@
  */
 import { z } from "zod";
 import * as core from "../core/market.js";
+import { MARKET_MOVER_VIEWS } from "../http/transport.js";
+import type { MarketMoverView } from "../http/transport.js";
 import { runTool } from "./_format.js";
 import type { Definer } from "./_define.js";
 
@@ -35,9 +37,16 @@ export function registerMarketTools(define: Definer): void {
       "series. Volume on that route comes back NULL, not 0 — a field that arrived empty on every " +
       "bar is absent, and `warnings` names every such field. `mapped`, `extraKeys` and `sample` show " +
       "which wire keys were used and what else the point carried.\n" +
-      "raw=true returns the sibling chart endpoint's payload untouched instead of bars. Use it only " +
-      "to discover real field spellings when `unmapped` or `extraKeys` is non-empty; it is not a " +
-      "fallback and returns no `bars`.",
+      "raw=true returns THIS ROUTE'S payload untouched instead of bars — the same request, with " +
+      "nothing projected. Use it only to discover real field spellings when `unmapped` or " +
+      "`extraKeys` is non-empty; it is not a fallback and returns no `bars`.\n" +
+      "raw=true used to read a DIFFERENT endpoint. It called /charts/:symbol while the projection " +
+      "reads /charts/:symbol/daily, and handed the first the second's vocabulary — so the escape " +
+      "hatch could not reproduce the payload it exists to diagnose. Measured 2026-09-01 the two do " +
+      "not share a vocabulary: /charts/:symbol REFUSES 1w with 400 \"Kurun waktu tidak valid\" and " +
+      "answers `{chart_points: []}` for everything else, while the daily route accepts 1w and " +
+      "answers the rich payload. That is why 1w errored and 1m came back empty — the route was " +
+      "wrong, not the value. Fixed: raw now reads the same route as the projection.",
     {
       symbol: z.string().describe("IDX ticker, e.g. BBRI"),
       timeframe: z
@@ -67,6 +76,16 @@ export function registerMarketTools(define: Definer): void {
       "default, which is not necessarily ALL.\n" +
       "grouped=true reads a different endpoint that returns the tape aggregated rather than print by " +
       "print. It is not a display option: the two return different payloads.\n" +
+      "WHICH SESSION AM I LOOKING AT. Both views carry `data.date` and it is the answer — read it " +
+      "rather than assuming today. Measured 2026-09-01 after the ~18:00 WIB broker release, both " +
+      "served that same day. Broker-derived and foreign-derived figures across this API publish at " +
+      "roughly 18:00 WIB, so before that release a payload carrying YESTERDAY's date is correct and " +
+      "not yet published — it is not stale data and not a bug. market_movers' `foreign.isShown` is " +
+      "the explicit flag for the same thing and flips false to true across that release.\n" +
+      "INTRADAY BROKER ATTRIBUTION DOES NOT EXIST TO BE RETURNED. IDX closed broker codes on live " +
+      "running trade on 6 December 2021. So `is_broker_exists: false` with empty `buyer`/`seller` " +
+      "is an honest answer about the exchange, not a parse failure or a missing field — check that " +
+      "flag per row rather than concluding the projection broke.\n" +
       "THIS TAPE IS NOT LIVE. Measured against the live API during an open session, it runs about " +
       "EIGHT TO TEN MINUTES BEHIND and refreshes in bursts — its head sat unchanged for over three " +
       "minutes while the lag grew second for second, and the staleness is at Stockbit's origin, not " +
@@ -175,7 +194,17 @@ export function registerMarketTools(define: Definer): void {
       "it covers the WHOLE session rather than the first 100 prints. Only the top few brokers " +
       "appear (five on the reading above), so it ranks the session's main participants — it is not " +
       "a complete broker list. For the full table use broker summary or broker distribution.\n" +
-      "Covers the current session only, and is empty before the first print of the day.",
+      "WHICH SESSION, AND WHEN IT IS PUBLISHED. The payload states its own window — `from`, `to` " +
+      "and `date_session_info` — and that is the answer; read it rather than assuming today. " +
+      "Measured 2026-09-01 at 18:40 WIB, all three read that same trading day. Broker-derived data " +
+      "across this API publishes at roughly 18:00 WIB, so BEFORE that release this endpoint serves " +
+      "the PREVIOUS session and says so in `from`/`to`. That is correct and unpublished, not stale " +
+      "— the earlier claim that it 'covers the current session only, and is empty before the first " +
+      "print of the day' was never achievable and is withdrawn.\n" +
+      "CAUTION on `data_last_updated`: it is stamped with a `Z` suffix but the value is WIB. The " +
+      "2026-09-01 reading was \"2026-09-01T16:28:44Z\" at a moment when UTC was 11:28 — five hours " +
+      "in the future, and 16:28 WIB is minutes after the 16:15 close, which is the only reading " +
+      "that makes sense. Do NOT parse this field as UTC; it is seven hours ahead of what it claims.",
     { symbol: z.string().describe("IDX ticker, e.g. BBRI") },
     async (a) => runTool(() => core.getRunningTradeChart(a.symbol as string)),
     // Settled by a live call on 2026-09-01: every key named above was read out of a real response.
@@ -185,16 +214,52 @@ export function registerMarketTools(define: Definer): void {
 
   define.read(
     "market_movers",
-    "Market movers from the order-trade service.\n" +
-      "This is a DIFFERENT endpoint from top_movers, which reads the hotlist. They are two services " +
-      "and are not guaranteed to agree; a disagreement is not evidence that either is wrong.\n" +
-      "Only `limit` is sent. This endpoint's category vocabulary (gainers vs losers vs most active) " +
-      "has not been observed, so no category filter is sent and you get whatever its default view " +
-      "is — check the payload to see which one that is rather than assuming gainers.\n" +
-      "An empty list is normal outside trading hours.\n" +
-      PENDING,
-    { limit: z.coerce.number().optional().describe("Max rows. Omitted takes the server default.") },
-    async (a) => runTool(() => core.getMarketMovers(a.limit as number | undefined)),
+    "The market movers behind Stockbit's own Movers dialog — the market-wide ranking.\n" +
+      "This is a DIFFERENT endpoint from top_movers, which reads the hotlist, and the difference is " +
+      "not cosmetic: measured 2026-09-01, the hotlist served NINE symbols while this served FIFTY, " +
+      "including structured warrants. Different universes. A symbol in one and not the other is " +
+      "expected, and a disagreement is not evidence that either is wrong. For a market-wide " +
+      "ranking, this is the one to use.\n" +
+      "`view` selects the tab, and the vocabulary is CLOSED to the eight members the server was " +
+      "seen to accept: topGainer, topLoser, topValue, topVolume, topFrequency, netForeignBuy, " +
+      "netForeignSell, bigMoneyNetValue. Each was echoed back verbatim on 2026-09-01, against a " +
+      "control value that answers 400 — so this endpoint rejects members it does not know rather " +
+      "than silently serving its default, which is what makes the echo trustworthy. The result's " +
+      "`view` is that echo: what the server says it SERVED, not what you asked for.\n" +
+      "The UI's ninth tab, IEP/IEV, is NOT a view — ten spellings of it were refused. It is a " +
+      "field: every row carries `iepIev` with the indicative equilibrium price and volume. Those " +
+      "are only meaningful during pre-opening (08:45-09:00 WIB) and read zero outside it.\n" +
+      "`limit` is honoured, but the service caps the answer at 50 rows however large it is. `page` " +
+      "is ignored, and the payload's own pagination block reads all zeros on every call, so it is " +
+      "not reported rather than passed through as a fake answer about whether more rows exist.\n" +
+      "Every row carries `readFrom` naming the wire key each value came from, `unmappedKeys` for " +
+      "anything this projection does not recognise, and the raw row.\n" +
+      "`foreign` says which session the net-foreign figures are from. `foreign.isShown` is the " +
+      "service's own flag for whether they mean anything yet: it reads false intraday and true " +
+      "after the ~18:00 WIB broker release on the same day. Foreign figures carrying yesterday's " +
+      "date before that release are correct and unpublished, not stale.\n" +
+      "An empty list is normal outside trading hours, though this endpoint served 50 rows with the " +
+      "market shut.",
+    {
+      view: z
+        .enum(MARKET_MOVER_VIEWS as [string, ...string[]])
+        .optional()
+        .describe("Which tab. Omitted takes the server's default view — read `view` to see which."),
+      limit: z.coerce
+        .number()
+        .optional()
+        .describe("Max rows. Honoured, but capped at 50 by the service. Omitted takes its default."),
+    },
+    async (a) =>
+      runTool(() =>
+        core.getMarketMovers({
+          view: a.view as MarketMoverView | undefined,
+          limit: a.limit as number | undefined,
+        }),
+      ),
+    // Settled by live calls on 2026-09-01: every member echoed, every projected key read out of a
+    // real row, and the limit/page/pagination behaviour measured rather than assumed.
+    { evidence: "observed" },
   );
 
   define.read(
@@ -253,35 +318,45 @@ export function registerMarketTools(define: Definer): void {
 
   define.read(
     "prices_batch",
-    "Last price for several symbols in one request.\n" +
-      "Returns `requested`, `found`, `missing` and `rows`. READ `missing` BEFORE USING THE ROWS. The " +
-      "multi-symbol encoding this endpoint wants has not been confirmed, and if it is the wrong one " +
-      "the server answers HTTP 200 with a single row instead of an error — `missing` listing almost " +
-      "everything you asked for is that failure, not a set of unlisted tickers.\n" +
-      "`missing` also does not prove a symbol has no price: it means no returned row mentioned that " +
-      "ticker. Symbols are matched against the rows' own string values rather than a named field, " +
-      "because the key the ticker lives under has not been observed.\n" +
-      "At most 50 symbols per call; split a longer list. For one symbol with orderbook depth use the " +
-      "orderbook or quote tools instead.\n" +
-      PENDING,
+    "A price SERIES for ONE symbol. Despite the name, this route does not batch — pass exactly one " +
+      "symbol.\n" +
+      "The multi-symbol question is settled and the answer is that there is no encoding. Measured " +
+      "2026-09-01: `stock_code=BBRI` returns 20 bare numbers under `data.prices`; comma-joining " +
+      "three symbols returns an EMPTY list; and the repeated-key form answers 400 \"too many values " +
+      "for field stock_code\". More than one symbol is therefore refused here rather than sent, " +
+      "because an empty list reads as \"these symbols have no prices\" — a claim about the market " +
+      "when the truth is a claim about the request.\n" +
+      "Note this returns a SERIES of prices, not one last price. For a single last price with " +
+      "orderbook depth use quote or orderbook. For several symbols, call this once per symbol.\n" +
+      "`missing` still does not prove a symbol has no price: it means no returned row mentioned " +
+      "that ticker. Symbols are matched against the rows' own string values rather than a named " +
+      "field, because the key the ticker lives under has not been observed.",
     {
-      symbols: z.array(z.string()).describe("IDX tickers, e.g. [\"BBRI\", \"TLKM\"]. Max 50, de-duplicated."),
+      symbols: z
+        .array(z.string())
+        .describe("Exactly ONE IDX ticker, e.g. [\"BBRI\"]. More than one is refused — see above."),
     },
     async (a) => runTool(() => core.getPricesBatch(a.symbols as string[])),
+    // Settled live 2026-09-01: every encoding tried, and the single-symbol series read off a real
+    // response. What is observed is the ROUTE's behaviour; the row projection is unchanged.
+    { evidence: "observed" },
   );
 
   define.read(
     "price_market",
-    "One symbol's prices broken down by market board for a session.\n" +
-      "boards takes uppercase names such as REGULER, NEGO or TUNAI and they are sent UNPREFIXED and " +
-      "unaltered. This API uses two mutually incompatible prefixed board vocabularies elsewhere " +
-      "(MARKET_BOARD_ on broker summary, MARKET_TYPE_ on broker distribution) and which, if either, " +
-      "applies here is unknown — so nothing is added to your value. If the result looks unfiltered, " +
-      "the spelling is the first thing to suspect.\n" +
-      "Omitting `date` reads the current session. A past date is served from a 5-minute cache since " +
-      "a closed session cannot change; today is cached for 3 seconds.\n" +
-      "An empty result for a past date most likely means that date was not a trading day.\n" +
-      PENDING,
+    "DOES NOT WORK. Use orderbook instead — its `market_data[]` already returns the per-board " +
+      "split (All Market / Regular / Nego / Cash) for a symbol.\n" +
+      "This is not a vocabulary problem and there is no argument that fixes it. Measured " +
+      "2026-09-01, /company-price-feed/prices/:symbol/market answers 400 \"Silahkan Periksa " +
+      "permintaan\" with NO query parameters at all. It also refuses every board spelling tried " +
+      "(REGULER, RG, regular, REGULAR, TN, NG, CASH, ALL, MARKET_TYPE_REGULAR, MARKET_TYPE_ALL, " +
+      "BOARD_REGULAR, 1, 0) under every key tried (market, board, market_type, type).\n" +
+      "The bare call being refused is what settles it: if sending nothing is also an error, no " +
+      "combination of arguments can be the answer. Earlier passes read these 400s as an unknown " +
+      "board vocabulary and kept guessing spellings; the control that was missing was the empty " +
+      "request.\n" +
+      "Calling this tool refuses immediately and names the alternative rather than spending a round " +
+      "trip to be told the request is invalid.",
     {
       symbol: z.string().describe("IDX ticker, e.g. BBRI"),
       date: z.string().optional().describe("Session date, YYYY-MM-DD. Omit for the current session."),

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -1170,11 +1170,26 @@ export function registerTools(
 
   defMarket.read(
     "top_movers",
-    "Top gainers, losers, or most-active IDX stocks (hotlist). Returns an empty list when the " +
-      "market is closed — that is expected, not an error.",
+    "Stockbit's HOTLIST — a small curated list, NOT a market-wide ranking. Use market_movers for " +
+      "the market-wide one.\n" +
+      "This matters because the two look interchangeable and are not. Measured 2026-09-01, every " +
+      "call to this hotlist returned the SAME NINE symbols — at limit 5, 25, 50 and 100 alike. " +
+      "`limit` is sent and the service ignores it. So the ranking you get is a correct ordering " +
+      "over a nine-symbol universe, not the top of the exchange, and reading it as 'today's top " +
+      "gainers on IDX' overstates it by a wide margin.\n" +
+      "That also disposes of a reported bug: a contiguous descending run of nine changes is what a " +
+      "correct sort over nine symbols looks like. There is nothing wrong with the ordering; the " +
+      "universe is simply small, and this description is the fix.\n" +
+      "market_movers reads a different service and returned 50 rows for the same moment, including " +
+      "structured warrants. The two disagreeing is expected and is not evidence that either is " +
+      "wrong.\n" +
+      "Returns an empty list when the market is closed — that is expected, not an error.",
     {
       type: z.enum(["topGainer", "topLoser", "mostActive"]).describe("Which hotlist"),
-      limit: z.coerce.number().optional().describe("Default 25"),
+      limit: z.coerce
+        .number()
+        .optional()
+        .describe("Sent, but the service ignores it — nine rows come back regardless. Default 25."),
     },
     async (a) => runTool(() => core.getTopMovers(a.type, a.limit ?? 25)),
   );
@@ -1223,7 +1238,20 @@ export function registerTools(
 
   defMarket.read(
     "orderbook",
-    "Full order-book depth ladder for a symbol.",
+    "Full order-book depth ladder for a symbol.\n" +
+      "UNITS, AND THEY ARE MIXED IN ONE RESPONSE. `volume` here is SHARES (e.g. 3,545,526,000) " +
+      "while `technicals`' `volumeLots` for the same symbol and session is LOTS (35,488,071). They " +
+      "reconcile at exactly 100 shares per lot — the IDX lot size — and neither figure is wrong. " +
+      "Worse, this same payload labels its `total_bid_offer` depth figures `lot` while carrying " +
+      "`volume` in shares a few keys away. Two units under similar names in one response is a " +
+      "silent-wrong-answer generator: check which one you are holding before comparing anything, " +
+      "and never compare `volume` here against `volumeLots` there without the ×100.\n" +
+      "`market_data[]` carries the per-board split (All Market / Regular / Nego / Cash). It is also " +
+      "the answer for anything price_market looks like it should do — that route cannot be called.\n" +
+      "FOREIGN FLOW HAS NO DATE ON THIS PAYLOAD. `fbuy`/`fsell`/`fnet` arrive with nothing saying " +
+      "which session they are from, and foreign flow publishes at roughly 18:00 WIB, so before that " +
+      "release they are the PREVIOUS session's. price_bands surfaces this as an explicitly null " +
+      "`dataAsOf` with a note; market_movers carries the date for real as `foreign.sessionDate`.",
     { symbol: z.string().describe("IDX ticker") },
     async (a) => runTool(() => core.getOrderbook(a.symbol)),
   );

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -59,8 +59,7 @@ import { forgetRotated } from "../auth/session.js";
 import { forceRefresh, hasStoredSession, resetSession } from "../auth/session.js";
 import { StockbitError } from "../http/errors.js";
 import { logoutSecurities } from "../auth/tradinglogin.js";
-import { acquireDirLock } from "../util/dirlock.js";
-import { stockbitPath } from "../paths.js";
+import { acquireLoginLock } from "../auth/loginlock.js";
 import { redactValue } from "../redact.js";
 import { browserSuppressed } from "../desktop/browser.js";
 
@@ -109,10 +108,12 @@ export async function settleLogin(result: LoginResult): Promise<void> {
     await forceRefresh("main");
     loginFinished("captured");
   } catch (err) {
-    // By STATUS, not by `kind`. `refreshOnce` labels every non-2xx `kind: "auth"`, including a 500,
-    // so `kind` cannot separate "Stockbit refused this credential" from "Stockbit was down" — and
-    // that is the whole distinction between the two outcomes below. 401 and 403 are the refusals,
-    // which is `kindForStatus`'s own definition of an auth failure.
+    // By STATUS, not by `kind`, and still by status after P7g made `refreshOnce` derive its kind
+    // from the status through `kindForStatus`. That fixed the case this comment used to be about —
+    // a 500 arriving labelled `auth` — but not the case it is about now: `auth` is also the kind of
+    // a throw carrying NO status, which is what "no credential reached the store" raises. Reading
+    // that as a refusal would report `captured-but-rejected` for a capture Stockbit never saw. 401
+    // and 403 are the refusals, and only a refusal is one.
     const rejected =
       err instanceof StockbitError && (err.status === 401 || err.status === 403);
     const message = err instanceof Error ? err.message : String(err);
@@ -121,9 +122,6 @@ export async function settleLogin(result: LoginResult): Promise<void> {
     loginFinished(`${rejected ? "captured-but-rejected" : "captured-unproven"}: ${String(redactValue(message))}`);
   }
 }
-
-/** How long the login lock is held before it is assumed to belong to a dead process. */
-const LOGIN_LOCK_STALE_MS = 20 * 60_000;
 
 /** The terminal fallback, quoted verbatim wherever a tool refuses to open a browser. */
 const CLI_LOGIN = "npx -y -p stockbit-mcp stockbit-auth login";
@@ -410,11 +408,11 @@ async function startLogin(define: Definer, request: LoginRequest) {
   }
 
   // A directory lock, not just the in-process flag: a second server instance (a different client,
-  // or the CLI) would otherwise drive the same browser profile at the same time.
-  const release = await acquireDirLock(stockbitPath("login.lock"), {
-    staleMs: LOGIN_LOCK_STALE_MS,
-    timeoutMs: 0,
-  });
+  // or the CLI) would otherwise drive the same browser profile at the same time. All three
+  // participants take it through `acquireLoginLock`, so none of them can hold it under a different
+  // staleness budget and break a lock the others are still using — `stockbit-auth login` took
+  // nothing at all until P7g, which is exactly the hole the comment above describes.
+  const release = await acquireLoginLock();
   if (!release) {
     return refusal(
       "Another login is already in progress — a lock is held on the browser profile, probably by a terminal or a second client.",

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -14,6 +14,8 @@ import {
   worstCaseHoldMsFor,
 } from "../src/auth/reflock.ts";
 import { parseRefresh, ensureFresh, resetSession, decodeJwt } from "../src/auth/session.ts";
+import { clearAccessCache } from "../src/auth/accesscache.ts";
+import { StockbitError, type ErrorKind } from "../src/http/errors.ts";
 import { buildUrl } from "../src/http/transport.ts";
 
 /** Build an unsigned JWT with a given exp (seconds). */
@@ -233,6 +235,73 @@ test("refresh persists a ROTATED refresh token (or we lock ourselves out)", asyn
     globalThis.fetch = realFetch;
     store.clear();
     resetSession();
+  }
+});
+
+test("a failed refresh is labelled by its STATUS, so an outage is not a revoked credential", async () => {
+  // `refreshOnce` used to throw `kind: "auth"` on both branches of its `!res.ok` — the ternary
+  // beside it picks the MESSAGE, not the kind — so a 502 from Stockbit's refresh endpoint was
+  // indistinguishable from a session Stockbit had revoked. That is not a cosmetic label:
+  // `analysis/analyze.ts` rethrows an `auth` cause in preference to every other failure, and
+  // `core/company.ts` explains one as a token-placement bug, so a network blip told the user their
+  // session was dead and offered to sign them out of their browser to fix it.
+  //
+  // One case per status CLASS, because the rule is a table and a single 502 would only prove the
+  // one row someone happened to think of. The expectations are `kindForStatus`'s own — deliberately
+  // written out here rather than computed from it, so this test disagrees with a bad edit to that
+  // table instead of agreeing with it (the WRITES-list rule).
+  const cases: [number, ErrorKind][] = [
+    [400, "invalid_param"],
+    [401, "auth"],
+    [403, "auth"],
+    [429, "rate_limited"],
+    [500, "upstream"],
+    [502, "upstream"],
+  ];
+
+  const store = getStore();
+  const realFetch = globalThis.fetch;
+  try {
+    for (const [status, kind] of cases) {
+      // A distinct token per case, so nothing can be served from a cache written by the last one.
+      store.set(`REFRESH-${status}`);
+      resetSession();
+      clearAccessCache("main");
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ message: `refused with ${status}` }), {
+          status,
+          headers: { "content-type": "application/json" },
+        })) as typeof fetch;
+
+      const err = await ensureFresh().then(
+        () => null,
+        (e: unknown) => e,
+      );
+      assert.ok(err instanceof StockbitError, `HTTP ${status} must throw a StockbitError, got ${String(err)}`);
+      assert.equal(err.kind, kind, `HTTP ${status} must be kind ${kind}`);
+      // The status must survive on the error too: the two guards that unlock destructive advice
+      // (`src/auth/session.ts`'s escalation and `src/tools/system.ts`'s capture verdict) read it
+      // rather than the kind, because `auth` is also the kind of a throw that carries no status.
+      assert.equal(err.status, status, `HTTP ${status} must carry its status`);
+    }
+
+    // And the one auth failure that is NOT a refusal keeps its kind and carries no status at all —
+    // the state every new user is in. Narrowing those guards to a status is what would break here.
+    store.clear();
+    resetSession();
+    clearAccessCache("main");
+    const missing = await ensureFresh().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    assert.ok(missing instanceof StockbitError);
+    assert.equal(missing.kind, "auth", "no stored credential is still an auth failure");
+    assert.equal(missing.status, undefined, "nothing was sent, so there is no status to report");
+  } finally {
+    globalThis.fetch = realFetch;
+    store.clear();
+    resetSession();
+    clearAccessCache("main");
   }
 });
 

--- a/test/authcli.test.ts
+++ b/test/authcli.test.ts
@@ -370,7 +370,21 @@ test("Ctrl-C during a login releases the lock — an exit listener alone does NO
   } finally {
     rmSync(store, { recursive: true, force: true });
   }
-});
+},
+  {
+    // Not a platform caveat on the FIX — a real console Ctrl-C on Windows does deliver SIGINT and
+    // does run the handler, so the lock is released there too. What Windows lacks is the way this
+    // test SIMULATES it: `child.kill("SIGINT")` terminates the process outright rather than
+    // delivering a signal, so the handler never gets the chance and the assertion fails for a
+    // reason that says nothing about the behaviour under test.
+    //
+    // SIGTERM is separately a no-op on Windows — node cannot listen for it — which the handler
+    // registration tolerates and nothing here can improve.
+    skip:
+      process.platform === "win32"
+        ? "child.kill('SIGINT') on Windows terminates without delivering the signal, so Ctrl-C cannot be simulated"
+        : false,
+  });
 
 /* ------------------------------ the wiring, by source scan ------------------------------ */
 

--- a/test/authcli.test.ts
+++ b/test/authcli.test.ts
@@ -13,7 +13,7 @@
  * gate were deleted, `login --help` would exit 1 having done nothing — a loud test failure, and no
  * browser. (`STOCKBIT_NO_BROWSER` alone would not do: `captureViaBrowserLogin` never checks it.)
  */
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -161,9 +161,16 @@ const execFileAsync = promisify(execFile);
  * Run the real CLI. The child gets its own empty store and the browser tripwire — see the header.
  * `--import tsx` from the repo root is the same loader `npm test` itself uses, so this is portable
  * exactly as far as the suite already is.
+ *
+ * `store` hands the child a directory the CALLER owns and keeps: the login-lock tests need to seed
+ * `login.lock` before the run and to read the directory after it, which the disposable store this
+ * makes by default has already deleted by the time the assertion runs.
  */
-async function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
-  const childStore = mkdtempSync(join(tmpdir(), "stockbit-authcli-child-"));
+async function runCli(
+  args: string[],
+  opts: { store?: string } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const childStore = opts.store ?? mkdtempSync(join(tmpdir(), "stockbit-authcli-child-"));
   try {
     const env = {
       ...process.env,
@@ -190,7 +197,7 @@ async function runCli(args: string[]): Promise<{ code: number; stdout: string; s
       return { code: e.code ?? -1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
     }
   } finally {
-    rmSync(childStore, { recursive: true, force: true });
+    if (!opts.store) rmSync(childStore, { recursive: true, force: true });
   }
 }
 
@@ -235,6 +242,81 @@ test("an unknown subcommand still gets usage on stderr and exit 2", async () => 
   const r = await runCli(["definitely-not-a-command"]);
   assert.equal(r.code, 2);
   assert.match(r.stderr, /Usage: stockbit-auth/);
+});
+
+/* ------------------------------ the login lock ------------------------------ */
+
+/**
+ * The hole P7g closed: `login.lock` is a five-gate safety property, and gate 5 of automatic login
+ * recovery is "the lock is free". This bin took nothing, so that gate read FREE for the whole time
+ * a `stockbit-auth login` was driving `~/.stockbit/browser-profile` — and an unattended recovery
+ * could open a second browser onto the profile the user was typing their password into. The MCP
+ * `login` tool's own comment names the CLI as the thing the lock protects against.
+ *
+ * Spawned rather than called, because the lock is a property of the PROCESS: the acquisition, the
+ * refusal, and the release-on-exit all live in the bin, and the release in particular is an `exit`
+ * listener that only exists in a real process.
+ */
+test("login refuses while another process holds the profile lock, before promising a window", async () => {
+  const store = mkdtempSync(join(tmpdir(), "stockbit-authcli-held-"));
+  // A bare directory, exactly as a holder that died mid-login would leave it: no owner token, so a
+  // release from this run could only remove it by breaking the rule in `releaseDecision`.
+  mkdirSync(join(store, "login.lock"), { recursive: true });
+  try {
+    const r = await runCli(["login"], { store });
+    assert.equal(r.code, 1, r.stderr);
+    assert.match(r.stderr, /Another login is already in progress/);
+    assert.match(r.stderr, /lock is held on the browser profile/);
+    // The refusal must come BEFORE cmdLogin's first line. "Opening a browser…" followed by a
+    // refusal is a report of something that did not happen, and this is the assertion — not the
+    // exit code — that proves no capture was reached.
+    assert.doesNotMatch(r.stdout + r.stderr, /Opening a browser/);
+    assert.ok(existsSync(join(store, "login.lock")), "a refused login must never delete the holder's lock");
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("trading-login --browser takes the same lock — it drives the same profile", async () => {
+  // The other CLI participant, and the one that is easy to forget: it reaches the identical
+  // `captureViaBrowserLogin` on the identical default profile, so a PIN modal in one window and a
+  // recovery launching into the other is the same wreck as two logins.
+  //
+  // Safe to spawn only because the lock is held: the refusal is the FIRST thing in the `--browser`
+  // branch, so this run exits before any browser code is reached — which the "Opening the
+  // logged-in browser" assertion below is what proves. (The PIN branch is deliberately not locked;
+  // it posts to carina and opens nothing.)
+  const store = mkdtempSync(join(tmpdir(), "stockbit-authcli-trading-"));
+  mkdirSync(join(store, "login.lock"), { recursive: true });
+  try {
+    const r = await runCli(["trading-login", "--browser"], { store });
+    assert.equal(r.code, 1, r.stderr);
+    assert.match(r.stderr, /Another login is already in progress/);
+    assert.doesNotMatch(r.stdout + r.stderr, /Opening the logged-in browser/);
+    assert.ok(existsSync(join(store, "login.lock")), "a refused capture must never delete the holder's lock");
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("a login that FAILS still releases the lock — a leak recreates the stale lock it prevents", async () => {
+  // The failure path, not the happy one, because that is where a lock is lost: `cmdLogin` leaves
+  // through `process.exit` in five places and a `finally` would run in none of them. Here the
+  // browser tripwire makes `findBrowsers()` throw, so the run dies at the top-level `main().catch`
+  // — the hardest of those paths — with the lock already taken.
+  //
+  // A leak is not a tidiness problem. `login.lock` is only broken as stale after twenty minutes, so
+  // one leaked lock refuses every login AND every automatic recovery for that long, on behalf of a
+  // process that has already exited. That is the condition `reap_orphans` was written to clean up.
+  const store = mkdtempSync(join(tmpdir(), "stockbit-authcli-leak-"));
+  try {
+    const r = await runCli(["login"], { store });
+    assert.equal(r.code, 1, "precondition: the tripwire must make this login fail");
+    assert.match(r.stderr, /Opening a browser/, "precondition: it got past the lock and into the capture");
+    assert.equal(existsSync(join(store, "login.lock")), false, "the lock outlived the process that held it");
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
 });
 
 /* ------------------------------ the wiring, by source scan ------------------------------ */

--- a/test/authcli.test.ts
+++ b/test/authcli.test.ts
@@ -13,11 +13,11 @@
  * gate were deleted, `login --help` would exit 1 having done nothing — a loud test failure, and no
  * browser. (`STOCKBIT_NO_BROWSER` alone would not do: `captureViaBrowserLogin` never checks it.)
  */
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 
 const STORE = mkdtempSync(join(tmpdir(), "stockbit-authcli-test-"));
@@ -314,6 +314,59 @@ test("a login that FAILS still releases the lock — a leak recreates the stale 
     assert.equal(r.code, 1, "precondition: the tripwire must make this login fail");
     assert.match(r.stderr, /Opening a browser/, "precondition: it got past the lock and into the capture");
     assert.equal(existsSync(join(store, "login.lock")), false, "the lock outlived the process that held it");
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("Ctrl-C during a login releases the lock — an exit listener alone does NOT run on a signal", async () => {
+  // The regression this guards is specific and was nearly shipped. Node does not run `exit`
+  // listeners when a signal terminates the process by default — measured: a script that registers
+  // one and then sends itself SIGINT exits 130 without the listener printing. So releasing only
+  // from `process.once("exit", …)` leaks `login.lock` on Ctrl-C.
+  //
+  // And Ctrl-C is not an edge case for THIS command: it hands a human fifteen minutes to type into
+  // a browser window, so interrupting it is the ordinary way to change your mind. Before the CLI
+  // took a lock at all, that cost nothing. With an exit-only release it would cost twenty minutes
+  // in which every login and every unattended recovery is refused on behalf of a dead process —
+  // a REGRESSION, not a leftover risk. Taking a lock is only an improvement if releasing it is at
+  // least as reliable as never having taken it.
+  const store = mkdtempSync(join(tmpdir(), "stockbit-authcli-sigint-"));
+  try {
+    // A "browser" that exists and then blocks, so the CLI gets past `findBrowsers()`, takes the
+    // lock, and is still alive to be interrupted. The tripwire the other tests use exits at once,
+    // which is the wrong shape for this one.
+    const stub = join(store, "blocking-browser");
+    writeFileSync(stub, "#!/bin/sh\nexec sleep 120\n", { mode: 0o755 });
+
+    const child = spawn(process.execPath, ["--import", "tsx", BIN, "login"], {
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        STOCKBIT_NO_UPDATE_CHECK: "1",
+        STOCKBIT_FORCE_FILE_STORE: "1",
+        STOCKBIT_STORE_DIR: store,
+        STOCKBIT_BROWSER: stub,
+      },
+      stdio: "ignore",
+    });
+
+    try {
+      const lock = join(store, "login.lock");
+      // Wait for the lock to appear, so the interrupt lands while it is genuinely held rather than
+      // before it was taken — which would pass for the wrong reason.
+      const deadline = Date.now() + 30_000;
+      while (!existsSync(lock) && Date.now() < deadline) await new Promise((r) => setTimeout(r, 50));
+      assert.ok(existsSync(lock), "precondition: the CLI must have taken the lock before we interrupt it");
+
+      const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
+      child.kill("SIGINT");
+      await exited;
+
+      assert.equal(existsSync(lock), false, "Ctrl-C left the lock behind, refusing every login for 20 minutes");
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    }
   } finally {
     rmSync(store, { recursive: true, force: true });
   }

--- a/test/authcli.test.ts
+++ b/test/authcli.test.ts
@@ -319,7 +319,27 @@ test("a login that FAILS still releases the lock — a leak recreates the stale 
   }
 });
 
-test("Ctrl-C during a login releases the lock — an exit listener alone does NOT run on a signal", async () => {
+test(
+  "Ctrl-C during a login releases the lock — an exit listener alone does NOT run on a signal",
+  {
+    // Not a caveat on the FIX — a real console Ctrl-C on Windows does deliver SIGINT and does run
+    // the handler, so the lock is released there too. What Windows lacks is the way this test
+    // SIMULATES it: `child.kill("SIGINT")` terminates the process outright rather than delivering a
+    // signal, so the handler never gets its chance and the assertion would fail for a reason that
+    // says nothing about the behaviour under test.
+    //
+    // SIGTERM is separately a no-op on Windows — node cannot listen for it — which the handler
+    // registration tolerates and nothing here can improve.
+    //
+    // Options go BEFORE the function: `test(name, options, fn)`. Passing them after the callback
+    // parses fine and is silently ignored, which is how the first attempt at this skip shipped a
+    // Windows failure that looked exactly like the bug it was meant to document.
+    skip:
+      process.platform === "win32"
+        ? "child.kill('SIGINT') on Windows terminates without delivering the signal, so Ctrl-C cannot be simulated"
+        : false,
+  },
+  async () => {
   // The regression this guards is specific and was nearly shipped. Node does not run `exit`
   // listeners when a signal terminates the process by default — measured: a script that registers
   // one and then sends itself SIGINT exits 130 without the listener printing. So releasing only
@@ -348,15 +368,36 @@ test("Ctrl-C during a login releases the lock — an exit listener alone does NO
         STOCKBIT_STORE_DIR: store,
         STOCKBIT_BROWSER: stub,
       },
-      stdio: "ignore",
+      stdio: ["ignore", "ignore", "pipe"],
     });
 
     try {
       const lock = join(store, "login.lock");
-      // Wait for the lock to appear, so the interrupt lands while it is genuinely held rather than
-      // before it was taken — which would pass for the wrong reason.
-      const deadline = Date.now() + 30_000;
-      while (!existsSync(lock) && Date.now() < deadline) await new Promise((r) => setTimeout(r, 50));
+      // Synchronise on the child's OWN output, not on the lock file appearing.
+      //
+      // `holdLoginLock` creates the lock directory inside `acquireLoginLock()` and registers the
+      // signal handlers a few statements later, so "the lock exists" is true slightly BEFORE the
+      // handlers are installed. Polling for the file and firing immediately raced that window —
+      // fine when this file runs alone, and a real failure under the loaded machine of a full suite
+      // run, which is exactly the kind of flake that gets muted rather than fixed.
+      //
+      // "Opening a browser…" is `cmdLogin`'s first line and it prints only AFTER `holdLoginLock`
+      // has returned, so it is proof the handlers are in place. Deterministic, not a sleep.
+      let seen = "";
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`child never opened a browser; saw: ${seen}`)), 60_000);
+        child.stderr?.on("data", (c) => {
+          seen += String(c);
+          if (seen.includes("Opening a browser")) {
+            clearTimeout(timer);
+            resolve();
+          }
+        });
+        child.once("exit", () => {
+          clearTimeout(timer);
+          reject(new Error(`child exited before opening a browser; saw: ${seen}`));
+        });
+      });
       assert.ok(existsSync(lock), "precondition: the CLI must have taken the lock before we interrupt it");
 
       const exited = new Promise<number | null>((resolve) => child.once("exit", (code) => resolve(code)));
@@ -370,21 +411,7 @@ test("Ctrl-C during a login releases the lock — an exit listener alone does NO
   } finally {
     rmSync(store, { recursive: true, force: true });
   }
-},
-  {
-    // Not a platform caveat on the FIX — a real console Ctrl-C on Windows does deliver SIGINT and
-    // does run the handler, so the lock is released there too. What Windows lacks is the way this
-    // test SIMULATES it: `child.kill("SIGINT")` terminates the process outright rather than
-    // delivering a signal, so the handler never gets the chance and the assertion fails for a
-    // reason that says nothing about the behaviour under test.
-    //
-    // SIGTERM is separately a no-op on Windows — node cannot listen for it — which the handler
-    // registration tolerates and nothing here can improve.
-    skip:
-      process.platform === "win32"
-        ? "child.kill('SIGINT') on Windows terminates without delivering the signal, so Ctrl-C cannot be simulated"
-        : false,
-  });
+});
 
 /* ------------------------------ the wiring, by source scan ------------------------------ */
 

--- a/test/brokers.test.ts
+++ b/test/brokers.test.ts
@@ -1053,20 +1053,35 @@ test("bandar: unreadable rows are left out of the totals, not counted as zero", 
 
 /* ------------------------------ the tool surface ------------------------------ */
 
-/** A Definer that records instead of registering, so the tool layer can be driven directly. */
-function fakeDefiner(): { definer: Definer; reads: Map<string, ToolHandler>; writes: string[] } {
+/**
+ * A Definer that records instead of registering, so the tool layer can be driven directly.
+ *
+ * `shapes` is recorded as well as `reads`, and that is not incidental. Driving only the handler
+ * proves what the CORE does with an argument, never that the argument is in the tool's schema at
+ * all — and the SDK strips anything the schema does not declare before a handler ever sees it. A
+ * test that calls `handler({period})` on a tool whose shape has no `period` passes while the real
+ * server silently drops the field, which is the precise failure `broker_activity` is here to avoid.
+ */
+function fakeDefiner(): {
+  definer: Definer;
+  reads: Map<string, ToolHandler>;
+  shapes: Map<string, Record<string, unknown>>;
+  writes: string[];
+} {
   const reads = new Map<string, ToolHandler>();
+  const shapes = new Map<string, Record<string, unknown>>();
   const writes: string[] = [];
   const definer: Definer = {
-    read: (name, _description, _shape, handler) => {
+    read: (name, _description, shape, handler) => {
       reads.set(name, handler);
+      shapes.set(name, (shape ?? {}) as Record<string, unknown>);
     },
     write: (name) => {
       writes.push(name);
     },
     writeNames: () => [...writes],
   };
-  return { definer, reads, writes };
+  return { definer, reads, shapes, writes };
 }
 
 test("tools: four reads, no writes, and the arguments the model sends reach the wire", async () => {
@@ -1104,8 +1119,18 @@ test("tools: four reads, no writes, and the arguments the model sends reach the 
 });
 
 test("tools: broker_activity still ACCEPTS `period` in its schema, so it can refuse it out loud", async () => {
-  const { definer, reads } = fakeDefiner();
+  const { definer, reads, shapes } = fakeDefiner();
   registerBrokerTools(definer);
+
+  // The half this test used to leave unproven. Driving the handler shows the core refuses `period`;
+  // it says nothing about whether the SCHEMA declares it, and the SDK strips undeclared keys before
+  // a handler runs. Without this assertion the whole test passes against a tool that dropped
+  // `period` from its shape — which is the silent narrowing it exists to prevent, not a variant of
+  // it.
+  assert.ok(
+    Object.keys(shapes.get("broker_activity") ?? {}).includes("period"),
+    "period must stay in the schema: a stripped key is refused by nobody and reported to no one",
+  );
 
   // Deliberate: dropping `period` from the shape would have the SDK strip it, and the model would
   // read rows for a window it asked to change without ever learning the ask went nowhere. It

--- a/test/brokers.test.ts
+++ b/test/brokers.test.ts
@@ -11,6 +11,7 @@ import { getStore } from "../src/auth/store.ts";
 import { resetSession } from "../src/auth/session.ts";
 import { clearCache } from "../src/core/_util.ts";
 import {
+  BROKER_PERIODS,
   buildActivityParams,
   getBandarDetector,
   getBrokerActivity,
@@ -48,19 +49,100 @@ const DIRECTORY_BODY = {
   },
 };
 
+/**
+ * The envelope `brokerActivity` was measured returning on 2026-09-01, with no `period` sent:
+ * `data = {broker_activity_transaction, from, to, broker_code, broker_name}`.
+ *
+ * The row KEYS inside it were not recorded, so they are still spelled three ways here — the one the
+ * projection expects, a second plausible one, and a row it cannot read at all. The container is
+ * measured; what sits in it is not, and the fixture says which is which.
+ */
 const ACTIVITY_BODY = {
   data: {
-    list: [
+    broker_activity_transaction: [
       { symbol: "BBRI", net_value: "445525972000", total_volume: "1200" },
       { stock_code: "TLKM", net_value: "-2000000" },
       { unexpected: 1 },
     ],
+    from: "2026-09-01",
+    to: "2026-09-01",
+    broker_code: "YP",
+    broker_name: "Sekuritas Contoh Satu",
   },
 };
 
+/**
+ * The shape `brokerTop` was measured returning on 2026-09-01: rows under `data.list`, provenance
+ * under `data.date`, and every figure a PLAIN numeric string rather than the `{raw, formatted}`
+ * pair the rest of this API sends.
+ *
+ * Two properties of it are load-bearing and deliberate.
+ *
+ * It is ASCENDING by `total_value`, because the endpoint is — the biggest house is sent LAST, which
+ * is the whole defect. Any test that asserts a descending order off this fixture is asserting that
+ * the sort actually ran.
+ *
+ * `net_value`, `buy_value` and `sell_value` carry DISTINCT values, because they do live. A field
+ * report claimed all three were `"0"` on every row; the live reading contradicted it, so a fixture
+ * of zeroes here would quietly re-install the bug it would then look like it was testing.
+ */
 const TOP_BODY = {
+  data: {
+    list: [
+      {
+        code: "ZR",
+        name: "Sekuritas Contoh Kecil",
+        investor_type: "ALL",
+        total_value: "22485000",
+        net_value: "-15025000",
+        buy_value: "3730000",
+        sell_value: "18755000",
+        total_volume: "2200",
+        total_frequency: "17",
+        group: "LOKAL",
+      },
+      {
+        code: "CC",
+        name: "Sekuritas Contoh Menengah",
+        investor_type: "ALL",
+        total_value: "9912000000",
+        net_value: "1200000000",
+        buy_value: "5556000000",
+        sell_value: "4356000000",
+        total_volume: "410000",
+        total_frequency: "3011",
+        group: "LOKAL",
+      },
+      {
+        code: "AK",
+        name: "Sekuritas Contoh Besar",
+        investor_type: "ALL",
+        total_value: "5636360451396",
+        net_value: "-88000000000",
+        buy_value: "2774180225698",
+        sell_value: "2862180225698",
+        total_volume: "9100000",
+        total_frequency: "120455",
+        group: "ASING",
+      },
+      // A row that IS a row — it has a code — whose ranking figure will not parse. "1,234" is 1234
+      // under one Indonesian convention and 1.234 under the other, so it is refused, and a broker
+      // with no readable rank must not be given one.
+      { code: "XL", name: "Sekuritas Contoh Tak Terbaca", total_value: "1,234", net_value: "" },
+      { something_else: true },
+    ],
+    date: { from: "2026-09-01", to: "2026-09-01", idx: "2026-09-01" },
+  },
+};
+
+/**
+ * The permissive envelope, kept alive on purpose: `data` as a bare array, with no `date` beside it.
+ * Only `data.list` was measured, and a reader that stopped accepting the alternatives would be
+ * narrowing itself on the strength of one reading.
+ */
+const TOP_BARE_ARRAY_BODY = {
   data: [
-    { code: "AK", name: "UBS Sekuritas Indonesia", total_value: "9912000000" },
+    { code: "AK", name: "Sekuritas Contoh Besar", total_value: "9912000000" },
     { something_else: true },
   ],
 };
@@ -161,6 +243,9 @@ const requests = { directory: 0, activity: 0, top: 0, summary: 0 };
 /** What the next activity call should answer with. Lets one test drive an empty/odd envelope. */
 let activityBody: unknown = ACTIVITY_BODY;
 
+/** The same for the league table, so the measured shape and the permissive one both get a run. */
+let topBody: unknown = TOP_BODY;
+
 /** Set non-200 to make the directory route fail, so name resolution's degraded path is exercised. */
 let directoryStatus = 200;
 
@@ -202,7 +287,7 @@ before(() => {
     }
     if (u.includes("broker/top")) {
       requests.top++;
-      return json(TOP_BODY);
+      return json(topBody);
     }
     if (u.includes("marketdetectors/TLKM")) {
       requests.summary++;
@@ -228,6 +313,7 @@ beforeEach(() => {
   clearCache();
   seenUrls.length = 0;
   activityBody = ACTIVITY_BODY;
+  topBody = TOP_BODY;
   directoryStatus = 200;
   requests.directory = 0;
   requests.activity = 0;
@@ -456,7 +542,6 @@ test("directory: a rejected page size never reaches the wire", async () => {
 test("activity: market_type and investor_type REPEAT on the wire, never comma-joined", async () => {
   await getBrokerActivity({
     brokerCode: "yp",
-    period: "LAST_7_DAYS",
     // The duplicate is deliberate: it must collapse, not repeat.
     marketTypes: ["REGULER", "NEGO", "REGULER"],
     investorTypes: ["FOREIGN", "DOMESTIC"],
@@ -482,10 +567,45 @@ test("activity: market_type and investor_type REPEAT on the wire, never comma-jo
   assert.ok(!url.search.includes(","), `raw comma in ${url.search}`);
 
   assert.equal(url.searchParams.get("broker_code"), "YP");
-  assert.equal(url.searchParams.get("period"), "TB_PERIOD_LAST_7_DAYS");
   assert.equal(url.searchParams.get("sort_by"), "SORT_BY_NET_VALUE");
   assert.equal(url.searchParams.get("limit"), "20");
   assert.equal(url.searchParams.has("page"), false, "an omitted page must be absent, not empty");
+  assert.equal(url.searchParams.has("period"), false, "this endpoint 400s on every value of it");
+});
+
+test("activity: `period` is REFUSED with an explanation, not dropped on the way to the wire", async () => {
+  // Measured 2026-09-01: every one of the ten BROKER_PERIODS members answers 400 here, as do eight
+  // other spellings, while sending none answers 200 with rows. The control that makes that a fact
+  // about `period` and not about the call: unknown keys (`tb_period`, `periode`) answer 200 and are
+  // ignored, so a 400 is a RECOGNISED field refusing a value. There is no spelling left to find.
+  //
+  // Refused rather than silently dropped, because a filter the caller asked for and did not get is
+  // worse than one that errors: they would read rows for a window they never chose.
+  await assert.rejects(
+    () => getBrokerActivity({ brokerCode: "YP", period: "LAST_1_DAY" }),
+    (e: unknown) => {
+      assert.ok(e instanceof StockbitError);
+      assert.equal(e.kind, "invalid_param");
+      assert.match(e.message, /no period filter/i);
+      // The message has to say where the window IS, or refusing it just loses the caller a window.
+      assert.match(e.message, /from.*to|`from`\/`to`/);
+      return true;
+    },
+  );
+  // The member its sibling accepts is refused here too — that pairing is the finding, so assert it.
+  await assert.rejects(() => getBrokerActivity({ brokerCode: "YP", period: "YEAR_TO_DATE" }), StockbitError);
+  assert.equal(requests.activity, 0, "a refused parameter must cost no request");
+});
+
+test("activity: BROKER_PERIODS is untouched — broker_distribution still uses it", async () => {
+  // The fix is "stop sending it HERE", not "delete the vocabulary". broker_distribution accepts
+  // TB_PERIOD_LAST_1_DAY on this same list, and narrowing the constant would break that route to
+  // fix this one.
+  assert.ok(BROKER_PERIODS.includes("LAST_1_DAY"));
+  assert.equal(BROKER_PERIODS.length, 10);
+  // And it is still live on the route that takes it.
+  await getBrokerTop({ period: "LAST_1_DAY" });
+  assert.equal(lastUrl("broker/top").searchParams.get("period"), "TB_PERIOD_LAST_1_DAY");
 });
 
 test("activity: omitted filters are absent parameters, not empty ones", async () => {
@@ -495,12 +615,48 @@ test("activity: omitted filters are absent parameters, not empty ones", async ()
   assert.equal(url.searchParams.get("broker_code"), "CC");
 });
 
+test("activity: binds to the measured row container and carries the window beside it", async () => {
+  const activity = await getBrokerActivity({ brokerCode: "YP" });
+
+  // `broker_activity_transaction` is the container the live call answered with. It used to be
+  // absent from ROW_CONTAINERS, so this tool returned `rowsFrom: null, count: 0` while `dataKeys`
+  // showed the array sitting right there.
+  assert.equal(activity.rowsFrom, "broker_activity_transaction");
+  assert.equal(activity.count, 3);
+  assert.deepEqual(activity.dataKeys, [
+    "broker_activity_transaction",
+    "from",
+    "to",
+    "broker_code",
+    "broker_name",
+  ]);
+
+  // With no period to choose, `from`/`to` are the ONLY thing dating these rows, and they were
+  // being read out of the envelope and thrown away.
+  assert.equal(activity.from, "2026-09-01");
+  assert.equal(activity.to, "2026-09-01");
+});
+
+test("activity: a window the response did not carry is absent, never today's date", async () => {
+  activityBody = { data: { broker_activity_transaction: [{ symbol: "BBRI" }] } };
+  const activity = await getBrokerActivity({ brokerCode: "YP" });
+  assert.equal(activity.count, 1);
+  assert.equal("from" in activity, false, "an unstated window is absent, not defaulted");
+  assert.equal("to" in activity, false);
+
+  // An empty string is Stockbit's "no value here" across this API, and must read the same way.
+  clearCache();
+  activityBody = { data: { broker_activity_transaction: [], from: "", to: "   " } };
+  const blank = await getBrokerActivity({ brokerCode: "CC" });
+  assert.equal("from" in blank, false);
+  assert.equal("to" in blank, false);
+});
+
 test("activity: projects the traded symbol and leaves the figures in the raw row", async () => {
   const activity = await getBrokerActivity({ brokerCode: "YP" });
 
   assert.equal(activity.brokerCode, "YP");
   assert.deepEqual(activity.request, { broker_code: "YP" });
-  assert.equal(activity.rowsFrom, "list");
   assert.equal(activity.count, 3);
 
   assert.equal(activity.rows[0].symbol, "BBRI");
@@ -544,6 +700,7 @@ test("activity: rejected arguments never reach the wire", async () => {
   await assert.rejects(() => getBrokerActivity({ brokerCode: "YP/../x" }), StockbitError);
   // A plausible misspelling of a board. It must fail here rather than be sent and ignored.
   await assert.rejects(() => getBrokerActivity({ brokerCode: "YP", marketTypes: ["REGULAR"] }), StockbitError);
+  // A period this vocabulary never had, and one it does — both refused, for the same reason now.
   await assert.rejects(() => getBrokerActivity({ brokerCode: "YP", period: "LAST_30_DAYS" }), StockbitError);
   await assert.rejects(() => getBrokerActivity({ brokerCode: "YP", sortBy: "net value" }), StockbitError);
   assert.equal(requests.activity, 0);
@@ -560,8 +717,9 @@ test("activity: the built parameters keep the lists as arrays, with no round-tri
   assert.deepEqual(params.market_type, ["MARKET_TYPE_REGULER", "MARKET_TYPE_NEGO"]);
   assert.deepEqual(params.investor_type, ["INVESTOR_TYPE_FOREIGN"]);
   assert.equal(params.broker_code, "YP");
-  assert.equal(params.period, undefined);
   assert.equal(params.sort_by, undefined);
+  // Not merely undefined: the key is not built at all, so nothing downstream can resurrect it.
+  assert.equal("period" in params, false, "period is never a parameter of this route");
 });
 
 test("activity: the cache key carries every filter, not just the broker", async () => {
@@ -572,13 +730,13 @@ test("activity: the cache key carries every filter, not just the broker", async 
   await getBrokerActivity({ brokerCode: "YP", marketTypes: ["ALL"] });
   assert.equal(requests.activity, 2, "a different board must not be served the REGULER answer");
 
-  await getBrokerActivity({ brokerCode: "YP", marketTypes: ["REGULER"], period: "LAST_7_DAYS" });
-  assert.equal(requests.activity, 3, "a different window must not be served the earlier answer");
+  await getBrokerActivity({ brokerCode: "YP", marketTypes: ["REGULER"], sortBy: "TOTAL_VALUE" });
+  assert.equal(requests.activity, 3, "a different sort must not be served the earlier answer");
 });
 
 /* ------------------------------------ top ------------------------------------ */
 
-test("top: sends only what was asked for, and reads a bare data array", async () => {
+test("top: sends only what was asked for, on the declared path", async () => {
   const top = await getBrokerTop({ period: "YEAR_TO_DATE", sortBy: "TOTAL_VALUE" });
 
   const url = lastUrl("broker/top");
@@ -587,12 +745,158 @@ test("top: sends only what was asked for, and reads a bare data array", async ()
   assert.equal(url.searchParams.get("sort_by"), "SORT_BY_TOTAL_VALUE");
   assert.deepEqual([...url.searchParams.keys()].sort(), ["period", "sort_by"]);
 
+  assert.equal(top.rowsFrom, "list");
+  assert.deepEqual(top.request, { period: "TB_PERIOD_YEAR_TO_DATE", sort_by: "SORT_BY_TOTAL_VALUE" });
+  assert.deepEqual(top.unmapped, { count: 1, sampleKeys: ["something_else"] });
+});
+
+test("top: the biggest broker comes FIRST — the endpoint sends them ascending", async () => {
+  // The defect, in one assertion. Measured across all 89 live rows: first 22,485,000, last
+  // 5,636,360,451,396. A tool whose whole description is "which brokers moved the most" was
+  // handing back the smallest house at the top, and the ignored `limit` was the only thing hiding
+  // it — nobody ever looked past row three.
+  const top = await getBrokerTop();
+
+  assert.deepEqual(
+    top.brokers.map((b) => b.code),
+    ["AK", "CC", "ZR", "XL", undefined],
+    "descending by total_value, with the two unrankable rows last in wire order",
+  );
+  assert.deepEqual(top.brokers.map((b) => b.totalValue).slice(0, 3), [
+    5_636_360_451_396, 9_912_000_000, 22_485_000,
+  ]);
+
+  // Said out loud, because a client-side sort the caller cannot see is itself a silent behaviour.
+  // No `sort_by` value reverses the order upstream, so this is the only place it can happen.
+  assert.deepEqual(top.sortedLocally, {
+    by: "total_value",
+    direction: "descending",
+    appliedLocally: true,
+    unsortable: 2,
+  });
+});
+
+test("top: a row with no readable total_value is kept, ranked LAST, and never given a zero", async () => {
+  const top = await getBrokerTop();
+  const xl = top.brokers.find((b) => b.code === "XL")!;
+
+  // "1,234" is refused rather than guessed at — 1234 under one Indonesian convention, 1.234 under
+  // the other. Absent, not zero: a zero would rank this house dead last on a real figure.
+  assert.equal(xl.totalValue, undefined);
+  assert.equal(xl.readFrom.totalValue, undefined, "an unread key is not named as a source");
+  assert.equal(xl.row.total_value, "1,234", "the raw value is still there to read");
+  // An empty string is "no value here", not an unreadable one, and reads the same way: absent.
+  assert.equal(xl.netValue, undefined);
+
+  // It sits after every ranked row, in wire order. Sorting it to the top or the bottom by
+  // comparator accident would be inventing a position for a broker that has none.
+  assert.equal(top.brokers.at(-2)!.code, "XL");
+});
+
+test("top: the row figures are projected as numbers, and readFrom names every key", async () => {
+  const top = await getBrokerTop();
+  const ak = top.brokers[0];
+
+  assert.equal(ak.code, "AK");
+  assert.equal(ak.name, "Sekuritas Contoh Besar");
+  assert.equal(ak.investorType, "ALL");
+  assert.equal(ak.group, "ASING");
+  assert.equal(ak.totalValue, 5_636_360_451_396);
+  assert.equal(ak.totalVolume, 9_100_000);
+  assert.equal(ak.totalFrequency, 120_455);
+
+  // These three are the correction to the 2026-08-31 field report, which recorded them as "0" on
+  // every row and called them dead. The live reading has 89 distinct values; they are populated,
+  // they are projected normally, and nothing here reports them absent.
+  assert.equal(ak.netValue, -88_000_000_000);
+  assert.equal(ak.buyValue, 2_774_180_225_698);
+  assert.equal(ak.sellValue, 2_862_180_225_698);
+  assert.ok(ak.netValue! < 0, "the sign is the wire's: this house was a net seller");
+
+  assert.deepEqual(ak.readFrom, {
+    code: "code",
+    name: "name",
+    investorType: "investor_type",
+    totalValue: "total_value",
+    netValue: "net_value",
+    buyValue: "buy_value",
+    sellValue: "sell_value",
+    totalVolume: "total_volume",
+    totalFrequency: "total_frequency",
+    group: "group",
+  });
+  // Nothing is dropped on the way through, and the strings are still strings underneath.
+  assert.equal(ak.row.total_value, "5636360451396");
+});
+
+test("top: the session the table covers is carried, not dropped", async () => {
+  const top = await getBrokerTop();
+  assert.deepEqual(top.date, { from: "2026-09-01", to: "2026-09-01", idx: "2026-09-01" });
+});
+
+test("top: `limit` is applied HERE, after the sort, and is never sent", async () => {
+  const top = await getBrokerTop({ limit: 2 });
+
+  // The endpoint ignores its own `limit` — the same 89 rows at limit=3 and at limit=5 — so sending
+  // it would put a cap in `request` that the server never honoured.
+  assert.equal(lastUrl("broker/top").searchParams.has("limit"), false);
+  assert.equal("limit" in top.request, false);
+
+  // After the sort, not before: a cap applied to the wire order would return the two SMALLEST.
+  assert.deepEqual(
+    top.brokers.map((b) => b.code),
+    ["AK", "CC"],
+  );
+  assert.equal(top.count, 2);
+  assert.equal(top.countBeforeLimit, 5, "the caller can see what the trim removed");
+  assert.equal(top.limitAppliedLocally, 2, "and whose cap it was");
+});
+
+test("top: with no limit, nothing claims one was applied", async () => {
+  const top = await getBrokerTop();
+  assert.equal(top.limitAppliedLocally, undefined);
+  assert.equal(top.count, 5);
+  assert.equal(top.countBeforeLimit, 5);
+});
+
+test("top: trimming never mutates the shared cache entry, and costs no second fetch", async () => {
+  // Same trap as getBrokerDirectory's `codes`: `full` is the object every later caller of that key
+  // receives, and slicing its `brokers` in place would hand the next caller this caller's cap.
+  const two = await getBrokerTop({ limit: 2 });
+  assert.equal(two.count, 2);
+
+  const all = await getBrokerTop();
+  assert.equal(requests.top, 1, "limit is not on the wire, so it is not in the cache key either");
+  assert.equal(all.count, 5, "the untrimmed table must still be whole");
+  assert.equal(all.limitAppliedLocally, undefined);
+
+  const three = await getBrokerTop({ limit: 3 });
+  assert.equal(requests.top, 1, "a second cap is a second slice, not a second request");
+  assert.equal(three.count, 3);
+});
+
+test("top: a rejected limit never reaches the fetch", async () => {
+  await assert.rejects(() => getBrokerTop({ limit: 0 }), (e: unknown) => {
+    assert.ok(e instanceof StockbitError);
+    assert.equal(e.kind, "invalid_param");
+    return true;
+  });
+  await assert.rejects(() => getBrokerTop({ limit: "ten" }), StockbitError);
+  assert.equal(requests.top, 0);
+});
+
+test("top: still reads a bare data array, with no provenance to claim", async () => {
+  // Only `data.list` was measured. A reader that stopped accepting the alternatives would be
+  // narrowing itself on the strength of one reading.
+  topBody = TOP_BARE_ARRAY_BODY;
+  const top = await getBrokerTop();
+
   assert.equal(top.rowsFrom, "data");
   assert.equal(top.brokers[0].code, "AK");
-  assert.equal(top.brokers[0].name, "UBS Sekuritas Indonesia");
-  assert.equal(top.brokers[0].row.total_value, "9912000000");
+  assert.equal(top.brokers[0].totalValue, 9_912_000_000);
+  assert.equal(top.date, undefined, "a bare array carries no date, so none is invented");
   assert.deepEqual(top.unmapped, { count: 1, sampleKeys: ["something_else"] });
-  assert.deepEqual(top.request, { period: "TB_PERIOD_YEAR_TO_DATE", sort_by: "SORT_BY_TOTAL_VALUE" });
+  assert.equal(top.sortedLocally.unsortable, 1);
 });
 
 test("top: with no arguments it sends no query at all", async () => {
@@ -607,6 +911,14 @@ test("top: a different sort is a different cache entry", async () => {
   assert.equal(requests.top, 1);
   await getBrokerTop({ sortBy: "TOTAL_VOLUME" });
   assert.equal(requests.top, 2);
+});
+
+test("top: `unmapped` describes the row it actually came from, despite the re-sort", async () => {
+  // `unmappedOf` walks the raw rows and the projected ones in parallel, so it has to run BEFORE
+  // the sort. Counting after would report some other row's keys as the unreadable one's — and the
+  // sample keys are the whole diagnostic value of the field.
+  const top = await getBrokerTop();
+  assert.deepEqual(top.unmapped, { count: 1, sampleKeys: ["something_else"] });
 });
 
 /* ------------------------------- bandar detector ------------------------------- */
@@ -775,7 +1087,6 @@ test("tools: four reads, no writes, and the arguments the model sends reach the 
     broker_code: "XL",
     market_types: ["REGULER", "NEGO"],
     investor_types: ["FOREIGN"],
-    period: "LAST_1_DAY",
     sort_by: "TOTAL_VALUE",
     page: 2,
     limit: 10,
@@ -786,10 +1097,64 @@ test("tools: four reads, no writes, and the arguments the model sends reach the 
   assert.equal(url.searchParams.get("broker_code"), "XL");
   assert.deepEqual(url.searchParams.getAll("market_type"), ["MARKET_TYPE_REGULER", "MARKET_TYPE_NEGO"]);
   assert.deepEqual(url.searchParams.getAll("investor_type"), ["INVESTOR_TYPE_FOREIGN"]);
-  assert.equal(url.searchParams.get("period"), "TB_PERIOD_LAST_1_DAY");
   assert.equal(url.searchParams.get("sort_by"), "SORT_BY_TOTAL_VALUE");
   assert.equal(url.searchParams.get("page"), "2");
   assert.equal(url.searchParams.get("limit"), "10");
+  assert.equal(url.searchParams.has("period"), false);
+});
+
+test("tools: broker_activity still ACCEPTS `period` in its schema, so it can refuse it out loud", async () => {
+  const { definer, reads } = fakeDefiner();
+  registerBrokerTools(definer);
+
+  // Deliberate: dropping `period` from the shape would have the SDK strip it, and the model would
+  // read rows for a window it asked to change without ever learning the ask went nowhere. It
+  // reaches the core, which refuses it with an error the model can act on.
+  const result = (await reads.get("broker_activity")!({ broker_code: "YP", period: "LAST_1_DAY" })) as {
+    isError?: boolean;
+    content: Array<{ text: string }>;
+  };
+  assert.equal(result.isError, true);
+  const payload = JSON.parse(result.content[0].text) as { kind: string; message?: string; error?: string };
+  assert.equal(payload.kind, "invalid_param");
+  assert.match(JSON.stringify(payload), /no period filter/i);
+  assert.equal(requests.activity, 0);
+
+  // And a spelling the old enum would have bounced reaches the same explanation, rather than a zod
+  // error that tells the model only that its value is not in a list it should not be using.
+  const nonsense = (await reads.get("broker_activity")!({ broker_code: "YP", period: "daily" })) as {
+    isError?: boolean;
+    content: Array<{ text: string }>;
+  };
+  assert.equal(nonsense.isError, true);
+  assert.match(JSON.stringify(JSON.parse(nonsense.content[0].text)), /no period filter/i);
+});
+
+test("tools: broker_top's limit is applied locally and never reaches the wire", async () => {
+  const { definer, reads } = fakeDefiner();
+  registerBrokerTools(definer);
+
+  const result = await reads.get("broker_top")!({ limit: 1, sort_by: "TOTAL_VALUE" });
+  assert.equal((result as { isError?: boolean }).isError, false);
+
+  const url = lastUrl("broker/top");
+  assert.equal(url.searchParams.has("limit"), false);
+  assert.equal(url.searchParams.get("sort_by"), "SORT_BY_TOTAL_VALUE");
+
+  const payload = JSON.parse((result as { content: Array<{ text: string }> }).content[0].text) as {
+    data: {
+      brokers: Array<{ code?: string }>;
+      limitAppliedLocally?: number;
+      countBeforeLimit: number;
+      sortedLocally: { direction: string };
+    };
+  };
+  // Asserted through the SERIALISED result, which is what the model actually reads: a correction
+  // that survives only inside the core object is one the caller never sees.
+  assert.deepEqual(payload.data.brokers.map((b) => b.code), ["AK"], "the biggest, not the first sent");
+  assert.equal(payload.data.limitAppliedLocally, 1);
+  assert.equal(payload.data.countBeforeLimit, 5);
+  assert.equal(payload.data.sortedLocally.direction, "descending");
 });
 
 test("tools: bandar_detector passes its window and board through to the summary request", async () => {

--- a/test/chartbit.test.ts
+++ b/test/chartbit.test.ts
@@ -16,7 +16,7 @@
  */
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 process.env.STOCKBIT_FORCE_FILE_STORE = "1";
 process.env.STOCKBIT_STORE_DIR = mkdtempSync(join(tmpdir(), "stockbit-chartbit-test-"));
 
@@ -451,7 +451,11 @@ test("every chart session is opened inside the lock, and nothing re-enters it", 
   // while the property it protects was broken.
   const openers = allSourceFiles(SRC).filter((f) => /ChartbitSession\.open\s*\(/.test(readFileSync(f, "utf8")));
   assert.deepEqual(
-    openers.map((f) => f.slice(SRC.length + 1)),
+    // Separators normalised: `slice` leaves a NATIVE path, so on Windows this compared
+    // `chartbit\driver.ts` against a literal written with a forward slash and failed on a property
+    // that was perfectly true. The assertion is about WHICH FILE, never about how the OS spells a
+    // path — CI runs on three operating systems and a source scan must read the same on all of them.
+    openers.map((f) => f.slice(SRC.length + 1).split(sep).join("/")),
     ["chartbit/driver.ts"],
     "a module that opens a chart session outside driver.ts drives the browser outside the mutex",
   );

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -370,6 +370,37 @@ test("a payload of the wrong shape yields nulls rather than throwing", () => {
   }
 });
 
+test("the foreign figures say they cannot be dated, rather than implying they are today's", () => {
+  // R1. The orderbook payload carries fbuy/fsell/fnet and NO date, and foreign flow publishes at
+  // roughly 18:00 WIB — so before that release these are the previous session's and nothing on the
+  // response says so. The sharpest form: technicals has reported netForeignIdr 0 for today while
+  // orderbook reported -12.2B, and neither payload let a caller adjudicate.
+  const bands = extractBands("BBRI", { fbuy: 1000, fsell: 400, fnet: 600 });
+
+  assert.equal(bands.foreignNet, 600);
+  // Explicitly null, and null on EVERY payload — the date is genuinely not there, so any value
+  // here would be invented.
+  assert.equal(bands.dataAsOf, null);
+  assert.match(bands.noteAsOf, /18:00 WIB/, "the note must say when the figures publish");
+  assert.match(bands.noteAsOf, /market_movers/, "and where the date actually lives");
+});
+
+test("dataAsOf is null even when the payload is complete, because no date is ever on it", () => {
+  // Guards the tempting wrong fix: filling dataAsOf in from a second endpoint. That would attribute
+  // market_movers' date to orderbook's numbers, which is inventing a date with extra steps.
+  const complete = extractBands("BBRI", {
+    ara: 5200,
+    arb: 4400,
+    next_ara: 5320,
+    next_arb: 4510,
+    fbuy: 1,
+    fsell: 2,
+    fnet: 3,
+  });
+  assert.deepEqual(complete.missing, [], "every field present");
+  assert.equal(complete.dataAsOf, null, "and still no date, because the payload has none");
+});
+
 /* ------------------------------ the one wire reader ------------------------------ */
 
 test("wireNumber reads a value, or says it could not — it never invents a zero", () => {

--- a/test/corpaction.test.ts
+++ b/test/corpaction.test.ts
@@ -106,6 +106,47 @@ const PERFORMANCE = {
 
 const IPO = { data: [{ symbol: "RATU", offering_price: "1100", listing_date: "2026-01-08" }] };
 
+/**
+ * The market-wide day calendar: `data` is BUCKETED, one key per action kind, with a `today` string
+ * beside them. Twelve buckets come back every day and most of them are empty.
+ *
+ * The key ORDER copies the live 2026-09-01 response and is the whole point of the fixture: `bonus`
+ * is FIRST and it is EMPTY. A reader that binds to the first array it finds reports a day of
+ * nineteen actions as none, with a `rowsFrom` claiming it parsed the payload — which is worse than
+ * an empty answer, because `rowsFrom` is what tells "none today" from "not read". The per-bucket
+ * counts (dividend 1, economic 8, rups 1, warrant 9) are the live ones; the rows themselves are
+ * invented, as are the tickers.
+ */
+const CALENDAR_BUCKETS = {
+  message: "ok",
+  data: {
+    bonus: [],
+    dividend: [{ symbol: "AAAA", cum_date: "2026-09-01", ex_date: "2026-09-02", cash_dividend: "45" }],
+    // Not corporate actions — data releases, tied to no issuer. They are in the payload and in the
+    // row list all the same; see the test that pins that decision.
+    economic: Array.from({ length: 8 }, (_, i) => ({ event: `Release ${i + 1}`, country: "ID" })),
+    ipo: [],
+    pubex: [],
+    rightissue: [],
+    rups: [{ symbol: "BBBB", date: "2026-09-01", agenda: "RUPSLB" }],
+    // `stock_reverse` and `tender` are the calendar's spellings; the path segment vocabulary says
+    // `reversesplit` and `tenderoffer`. Kept as sent — see the tag test.
+    stock_reverse: [],
+    stocksplit: [],
+    tender: [],
+    warrant: Array.from({ length: 9 }, (_, i) => ({ symbol: `WRNT${i}`, instrument: `WRNT${i}-W` })),
+    stock_dividend: [],
+    today: "2026-09-01",
+  },
+};
+
+/** Every bucket present and empty: a real, quiet day. Not the same answer as a payload nobody read. */
+const CALENDAR_EMPTY = {
+  data: Object.fromEntries(
+    Object.entries(CALENDAR_BUCKETS.data).map(([key, value]) => [key, Array.isArray(value) ? [] : value]),
+  ),
+};
+
 /* ------------------------------- the fake wire ------------------------------- */
 
 type Reply = (pathname: string, params: URLSearchParams) => unknown;
@@ -540,6 +581,163 @@ test("an impossible date is refused before the request", async () => {
   await assert.rejects(() => getCalendarDay("2026-02-30"), /calendar date/i);
   await assert.rejects(() => getCalendarDay("20260803"), /YYYY-MM-DD/);
   assert.equal(seen.length, 0);
+});
+
+test("EVERY bucket is read, not the first one that happens to be an array", async () => {
+  // The defect, exactly: `bonus` sorts first in the live payload and is empty, so the reader bound
+  // to it and reported a nineteen-action day as `rows: []` with `rowsFrom: "data.bonus"` — the two
+  // together saying "parsed, and there is nothing", while the dividend, RUPS, warrant and economic
+  // rows sat in `meta`. BBCA going ex-dividend read as an empty calendar.
+  reply = () => CALENDAR_BUCKETS;
+  const day = await getCalendarDay();
+
+  assert.equal(day.rows.length, 19, "1 dividend + 8 economic + 1 rups + 9 warrant");
+  assert.notEqual(day.rowsFrom, "data.bonus", "binding to the first empty bucket is the regression");
+  assert.equal(
+    day.rowsFrom,
+    "data.{dividend,economic,rups,warrant}",
+    "rowsFrom names every bucket that contributed, because naming one implies the rest were read",
+  );
+  // Zeros included: a kind here with 0 came back empty, a kind missing from this map was not in the
+  // response at all. Nothing else in the answer can tell those two apart.
+  assert.deepEqual(day.buckets, {
+    bonus: 0,
+    dividend: 1,
+    economic: 8,
+    ipo: 0,
+    pubex: 0,
+    rightissue: 0,
+    rups: 1,
+    stock_reverse: 0,
+    stocksplit: 0,
+    tender: 0,
+    warrant: 9,
+    stock_dividend: 0,
+  });
+  // The non-array sibling is kept beside the rows rather than dropped, as it always was.
+  assert.deepEqual(day.meta, { today: "2026-09-01" });
+});
+
+test("each row says which bucket it came from, in the response's own spelling", async () => {
+  reply = () => CALENDAR_BUCKETS;
+  const day = await getCalendarDay();
+  const counted = day.rows.reduce<Record<string, number>>((acc, row) => {
+    const kind = String(row.corpactionType);
+    acc[kind] = (acc[kind] ?? 0) + 1;
+    return acc;
+  }, {});
+  assert.deepEqual(counted, { dividend: 1, economic: 8, rups: 1, warrant: 9 });
+  // The row is otherwise untouched: the tag is added, nothing is renamed or dropped.
+  assert.deepEqual(day.rows[0], {
+    symbol: "AAAA",
+    cum_date: "2026-09-01",
+    ex_date: "2026-09-02",
+    cash_dividend: "45",
+    corpactionType: "dividend",
+  });
+});
+
+test("a bucket name is never translated into the action_type vocabulary", async () => {
+  // The calendar spells two of the twelve kinds differently from the `/corpaction/{actionType}`
+  // path: `stock_reverse` and `tender` against `reversesplit` and `tenderoffer`. Rewriting one to
+  // the other would be a claim that they name the same thing, and no call here has settled that.
+  // The cost of not rewriting is visible and small: feeding `tender` to `corporate_actions` is
+  // refused as an unknown kind, which is a question, not a wrong answer.
+  reply = () => ({
+    data: {
+      bonus: [],
+      stock_reverse: [{ symbol: "CCCC", ratio: "10:1" }],
+      tender: [{ symbol: "DDDD", price: "980" }],
+    },
+  });
+  const day = await getCalendarDay();
+  assert.deepEqual(
+    day.rows.map((row) => row.corpactionType),
+    ["stock_reverse", "tender"],
+  );
+  assert.deepEqual(day.rowsFrom, "data.{stock_reverse,tender}");
+});
+
+test("the economic bucket is in the same list, and is countable on its own", async () => {
+  // Deliberate: an economic event is a data release, not a corporate action — but `economic` is
+  // already one of CORPACTION_TYPES and `corporate_actions(action_type:"economic")` fetches it from
+  // the same family, so splitting it out only here would be a second convention. Dropping it would
+  // also lose eight rows from a list whose question is "what is happening today". A caller who
+  // wants corporate actions alone has both handles: the tag and the count.
+  reply = () => CALENDAR_BUCKETS;
+  const day = await getCalendarDay();
+  assert.equal(day.buckets?.economic, 8);
+  assert.equal(day.rows.filter((row) => row.corpactionType !== "economic").length, 11);
+});
+
+test("all buckets empty is an empty DAY; a payload nobody read is still not", async () => {
+  reply = () => CALENDAR_EMPTY;
+  const day = await getCalendarDay();
+  assert.deepEqual(day.rows, []);
+  assert.equal(day.rowsFrom, "data.{}", "no bucket contributed, and all twelve were read");
+  assert.equal(Object.keys(day.buckets ?? {}).length, 12);
+  assert.deepEqual(
+    Object.values(day.buckets ?? {}),
+    Array(12).fill(0),
+    "every kind came back and every kind is empty — that is a quiet day, not an unread response",
+  );
+
+  clearCache();
+  reply = () => ({ data: { message: "maintenance", code: 7 } });
+  const unread = await getCalendarDay();
+  assert.equal(unread.rowsFrom, "unrecognized");
+  assert.equal("buckets" in unread, false, "no buckets key at all: nothing was bucketed");
+});
+
+test("the single-list shapes still read the way they always did", async () => {
+  // The bucket reader is an ADDITION. `corpaction/:actionType` and the rest answer with one list,
+  // and one array beside its siblings is still the nested shape, not a two-bucket calendar.
+  reply = () => ({ data: [{ symbol: "EEEE", action: "rups" }] });
+  const flat = await getCalendarDay();
+  assert.equal(flat.rowsFrom, "data");
+  assert.equal(flat.rows.length, 1);
+  assert.equal("buckets" in flat, false);
+  assert.equal("corpactionType" in flat.rows[0], false, "an untagged shape is never tagged by guess");
+
+  clearCache();
+  reply = () => CONVERSION;
+  const nested = await getCalendarDay();
+  assert.equal(nested.rowsFrom, "data.result", "one array with pagination beside it is not a bucket map");
+  assert.deepEqual(nested.meta, { total: 2, pagination: { page: 1, per_page: 20 } });
+  assert.equal("buckets" in nested, false);
+});
+
+test("the server's own today fills in the date, and dateFrom says where it came from", async () => {
+  reply = () => CALENDAR_BUCKETS;
+  const served = await getCalendarDay();
+  assert.equal(served.date, "2026-09-01", "null was wrong: the response said what day it is");
+  assert.equal(served.dateFrom, "data.today");
+
+  // A requested date wins — it is what was asked for. The server's value stays visible in `meta`,
+  // because whether `today` echoes the request or names the server's own day is not known here.
+  clearCache();
+  const asked = await getCalendarDay("2026-08-03");
+  assert.equal(asked.date, "2026-08-03");
+  assert.equal(asked.dateFrom, "request");
+  assert.deepEqual(asked.meta, { today: "2026-09-01" });
+});
+
+test("a today this code cannot read leaves the date null rather than guessing a day", async () => {
+  // `Date.parse("01/09/2026")` is the 9th of January, and this value is read as the day the rows
+  // describe. A confident wrong day is worse than no day; the raw string stays in `meta`.
+  reply = () => ({ data: { bonus: [], rups: [{ symbol: "FFFF" }], today: "01/09/2026" } });
+  const day = await getCalendarDay();
+  assert.equal(day.date, null);
+  assert.equal("dateFrom" in day, false, "no dateFrom without a date to have a provenance for");
+  assert.deepEqual(day.meta, { today: "01/09/2026" });
+});
+
+test("a range counts every bucket's rows, not the first bucket's", async () => {
+  // `rowsTotal` is what a caller skims to decide whether a window is worth reading.
+  reply = () => CALENDAR_BUCKETS;
+  const range = await getCalendarRange({ from: "2026-08-03", to: "2026-08-04" });
+  assert.equal(range.rowsTotal, 38, "19 rows on each of the two days");
+  assert.deepEqual(range.days.map((d) => d.dateFrom), ["request", "request"]);
 });
 
 /* ------------------------------- calendar range ------------------------------- */

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mapHttpError, StockbitError } from "../src/http/errors.ts";
+import { kindForStatus, mapHttpError, StockbitError } from "../src/http/errors.ts";
 
 test("maps 400 grpc-gateway envelope to invalid_param with details", () => {
   const e = mapHttpError(400, {
@@ -23,6 +23,25 @@ test("maps 404 and 429 and 5xx", () => {
   assert.equal(mapHttpError(404, "not found").kind, "not_found");
   assert.equal(mapHttpError(429, {}).kind, "rate_limited");
   assert.equal(mapHttpError(503, {}).kind, "upstream");
+});
+
+test("kindForStatus is the whole table, and it is the only copy of it", () => {
+  // Exported in P7g so `refreshOnce` could stop keeping a second, wrong copy of this rule — it
+  // labelled every non-ok refresh response `auth`, which made a 502 look like a revoked session.
+  // Asserted directly, not only through `mapHttpError`, because the auth path now calls it on its
+  // own and a change made for one caller must be visible to the other.
+  assert.equal(kindForStatus(400), "invalid_param");
+  assert.equal(kindForStatus(401), "auth");
+  assert.equal(kindForStatus(403), "auth");
+  assert.equal(kindForStatus(404), "not_found");
+  assert.equal(kindForStatus(429), "rate_limited");
+  assert.equal(kindForStatus(500), "upstream");
+  assert.equal(kindForStatus(502), "upstream");
+  // Nothing between the named refusals is guessed at. A 402 or a 418 is `unknown`, which is the
+  // honest answer — inventing `auth` for it is how a status nobody has observed starts telling
+  // users their session is dead.
+  assert.equal(kindForStatus(402), "unknown");
+  assert.equal(kindForStatus(418), "unknown");
 });
 
 test("toResult is a safe compact shape", () => {

--- a/test/market.test.ts
+++ b/test/market.test.ts
@@ -11,9 +11,9 @@ import { getStore } from "../src/auth/store.ts";
 import { resetSession } from "../src/auth/session.ts";
 import { clearCache } from "../src/core/_util.ts";
 import { StockbitError } from "../src/http/errors.ts";
+import { MARKET_MOVER_VIEWS } from "../src/http/transport.ts";
 import {
   CHART_TIMEFRAMES,
-  PRICES_BATCH_MAX,
   RUNNING_TRADE_MAX_LIMIT,
   getChartRaw,
   getMarketMovers,
@@ -315,13 +315,35 @@ test("the chart cache key distinguishes symbol and timeframe", async () => {
   assert.equal(requests, 3, "a different timeframe or symbol is a different answer");
 });
 
-test("raw reads the sibling chart route, not the daily one", async () => {
+test("raw reads the SAME route as the projection it exists to diagnose", async () => {
+  // This test used to assert the opposite, and the assertion was the bug. `raw` read
+  // /charts/:symbol while getSeriesBars reads /charts/:symbol/daily, and the two do not share a
+  // timeframe vocabulary — measured 2026-09-01, /charts/:symbol REFUSES `1w` with 400 "Kurun waktu
+  // tidak valid" and answers `{chart_points: []}` for everything else. So the escape hatch could
+  // not reproduce the payload it is for: `1w` errored and `1m` came back empty, and a caller read
+  // that emptiness as "the drift is gone".
+  //
+  // `raw: true` must differ from the projected call in exactly one way — that nothing is projected.
   responder = () => ({ data: { anything: true } });
   const raw = await getChartRaw("BBRI", "ytd");
   const url = lastUrl("/charts/");
-  assert.equal(url.pathname, "/charts/BBRI");
+  assert.equal(url.pathname, "/charts/BBRI/daily", "the same route getSeriesBars reads");
   assert.deepEqual(query(url), ["is_include_previous_historical=true", "timeframe=ytd"]);
   assert.deepEqual(raw, { anything: true });
+});
+
+test("raw and the projection request byte-identical URLs", async () => {
+  // The property the test above states in prose, asserted directly: if these ever diverge again,
+  // the escape hatch is describing a different request from the one that failed.
+  responder = () => CHART_POINTS;
+  await getSeriesBars("BBRI", "1y");
+  const projected = lastUrl("/charts/");
+  clearCache();
+  seenUrls = [];
+  await getChartRaw("BBRI", "1y");
+  const rawUrl = lastUrl("/charts/");
+  assert.equal(rawUrl.pathname, projected.pathname);
+  assert.deepEqual(query(rawUrl), query(projected));
 });
 
 /* ================================ running trade ================================ */
@@ -536,13 +558,170 @@ test("trade book chart is a different route, and is not held to the table's rule
 test("movers and top stocks send only what was asked for", async () => {
   await getMarketMovers();
   assert.deepEqual(query(lastUrl("/market-mover")), []);
-  await getMarketMovers(10);
+  await getMarketMovers({ limit: 10 });
   assert.deepEqual(query(lastUrl("/market-mover")), ["limit=10"]);
   await getTopStocks(5);
   const url = lastUrl("/top-stock");
   assert.equal(url.pathname, "/order-trade/top-stock");
   assert.deepEqual(query(url), ["limit=5"]);
   assert.equal(requests, 3, "three distinct argument sets, three requests");
+});
+
+/* ------------------------------- the movers surface ------------------------------- */
+
+/**
+ * One `mover_list` row in the shape measured live on 2026-09-01, plus one key this projection does
+ * not know so `unmappedKeys` has something to catch.
+ */
+const MOVER_PAYLOAD = {
+  data: {
+    mover_list: [
+      {
+        stock_detail: { code: "AAAA", name: "Alpha Tbk", icon_url: "", has_uma: false },
+        price: 1250,
+        change: { value: 40, percentage: 3.31 },
+        value: { raw: "477705146500", formatted: "477.7B" },
+        volume: { raw: "3545526000", formatted: "3.5B" },
+        frequency: { raw: "12043", formatted: "12,043" },
+        net_foreign_buy: { raw: "1200000", formatted: "1.2M" },
+        net_foreign_sell: { raw: "800000", formatted: "800K" },
+        net_buy: { raw: "400000", formatted: "400K" },
+        net_sell: { raw: "0", formatted: "0" },
+        iepiev_detail: {
+          iep: { raw: "1260", formatted: "1,260" },
+          iev: { raw: "5000", formatted: "5,000" },
+          ieval: { raw: "0", formatted: "-" },
+          iep_change: { raw: "0.8", formatted: "0.80%" },
+          iep_change_prev: { raw: "0", formatted: "0.00%" },
+          iep_price_diff: { raw: "10", formatted: "10" },
+          iep_prev_price_diff: { raw: "0", formatted: "0" },
+        },
+        big_money_net_value: { raw: "999", formatted: "999" },
+        market_cap: null,
+        a_key_this_projection_does_not_know: 1,
+      },
+    ],
+    mover_type: "MOVER_TYPE_TOP_GAINER",
+    is_show_net_foreign: true,
+    net_foreign_updated_at: "2026-09-01",
+    net_foreign_session_info: {
+      raw: 2,
+      formatted: "Updated 01 Sep 2026",
+      date: "2026-09-01",
+      is_last_session: true,
+    },
+    // Measured to be all zeros on every call regardless of what is sent. It must NOT be projected.
+    pagination: { page: 0, limit: 0, has_next: false, has_prev: false },
+  },
+};
+
+test("a mover view is sent as its wire member and read back from the ECHO", async () => {
+  responder = () => MOVER_PAYLOAD;
+  const result = await getMarketMovers({ view: "topGainer" });
+
+  // The friendly name never reaches the wire.
+  assert.deepEqual(query(lastUrl("/market-mover")), ["mover_type=MOVER_TYPE_TOP_GAINER"]);
+  // `view` is the server's echo, `requested` is what we asked for. They are separate on purpose.
+  assert.equal(result.view, "MOVER_TYPE_TOP_GAINER");
+  assert.equal(result.requested, "topGainer");
+  assert.equal(result.rowsFrom, "mover_list");
+  assert.equal(result.count, 1);
+});
+
+test("the echo is reported even when it disagrees with what was requested", async () => {
+  // The failure this guards: an endpoint that silently serves its default. `view` must describe
+  // what came back, so reading `requested` instead would hide exactly this.
+  responder = () => ({ ...MOVER_PAYLOAD, data: { ...MOVER_PAYLOAD.data, mover_type: "MOVER_TYPE_TOP_VALUE" } });
+  const result = await getMarketMovers({ view: "topGainer" });
+  assert.equal(result.requested, "topGainer");
+  assert.equal(result.view, "MOVER_TYPE_TOP_VALUE", "the echo, not the request");
+});
+
+test("a mover row is projected with readFrom, unmappedKeys and the raw row", async () => {
+  responder = () => MOVER_PAYLOAD;
+  const [row] = (await getMarketMovers({ view: "topGainer" })).rows;
+
+  assert.equal(row.symbol, "AAAA");
+  assert.equal(row.name, "Alpha Tbk");
+  assert.equal(row.price, 1250);
+  assert.equal(row.change, 40);
+  assert.equal(row.changePercent, 3.31);
+  // The {raw, formatted} shape: reading these with Number() once produced NaN for 100 symbols and
+  // looked like a dead market, which is why readRaw exists and why this asserts the number.
+  assert.equal(row.value, 477705146500);
+  assert.equal(row.volume, 3545526000);
+  assert.equal(row.frequency, 12043);
+  assert.equal(row.netForeignBuy, 1200000);
+  assert.equal(row.netForeignSell, 800000);
+
+  assert.equal(row.readFrom.symbol, "stock_detail.code");
+  assert.equal(row.readFrom.value, "value");
+  assert.equal(row.readFrom.changePercent, "change.percentage");
+
+  assert.deepEqual(row.unmappedKeys, ["a_key_this_projection_does_not_know"]);
+  assert.equal(row.row.price, 1250, "the raw row is kept whole");
+});
+
+test("iepIev is projected from the field, because IEP/IEV is not a view", async () => {
+  responder = () => MOVER_PAYLOAD;
+  const [row] = (await getMarketMovers({ view: "topGainer" })).rows;
+  assert.equal(row.iepIev?.iep, 1260);
+  assert.equal(row.iepIev?.iev, 5000);
+  assert.equal(row.iepIev?.iepChange, 0.8);
+  assert.equal(row.readFrom.iepIev, "iepiev_detail");
+});
+
+test("a row with no iepiev_detail reports it absent rather than zeroed", async () => {
+  responder = () => ({ data: { ...MOVER_PAYLOAD.data, mover_list: [{ stock_detail: { code: "BBBB" } }] } });
+  const [row] = (await getMarketMovers({ view: "topGainer" })).rows;
+  assert.equal(row.iepIev, undefined, "absent, not a block of zeros");
+  assert.equal(row.value, undefined, "a figure that was not on the wire is absent, not 0");
+  assert.equal(row.readFrom.value, undefined);
+});
+
+test("foreign provenance is carried, and the dead pagination block is not", async () => {
+  responder = () => MOVER_PAYLOAD;
+  const result = await getMarketMovers({ view: "topGainer" });
+  assert.deepEqual(result.foreign, {
+    isShown: true,
+    updatedAt: "2026-09-01",
+    sessionDate: "2026-09-01",
+    isLastSession: true,
+    sessionLabel: "Updated 01 Sep 2026",
+  });
+  // Measured all-zeros on every call including truncated ones, so passing it through would be
+  // inventing an answer about whether more rows exist.
+  assert.equal("pagination" in result, false);
+});
+
+test("every settled view is sendable and nothing else is", async () => {
+  responder = () => MOVER_PAYLOAD;
+  const expected: Record<string, string> = {
+    topGainer: "MOVER_TYPE_TOP_GAINER",
+    topLoser: "MOVER_TYPE_TOP_LOSER",
+    topValue: "MOVER_TYPE_TOP_VALUE",
+    topVolume: "MOVER_TYPE_TOP_VOLUME",
+    topFrequency: "MOVER_TYPE_TOP_FREQUENCY",
+    netForeignBuy: "MOVER_TYPE_NET_FOREIGN_BUY",
+    netForeignSell: "MOVER_TYPE_NET_FOREIGN_SELL",
+    bigMoneyNetValue: "MOVER_TYPE_BIG_MONEY_NET_VALUE",
+  };
+  assert.deepEqual(MARKET_MOVER_VIEWS.slice().sort(), Object.keys(expected).sort());
+  for (const [friendly, wire] of Object.entries(expected)) {
+    clearCache();
+    await getMarketMovers({ view: friendly as never });
+    assert.deepEqual(query(lastUrl("/market-mover")), [`mover_type=${wire}`]);
+  }
+});
+
+test("an unsettled view is refused locally, and IEP/IEV is named as the reason", async () => {
+  // Every IEP/IEV spelling was refused upstream on 2026-09-01, so shipping it as a member would
+  // tell the caller the server accepts a value nobody has seen it accept.
+  await assert.rejects(
+    () => getMarketMovers({ view: "iepIev" as never }),
+    (e: unknown) => e instanceof StockbitError && /IEP\/IEV/.test((e as Error).message),
+  );
+  assert.equal(requests, 0, "refused locally, without a round trip");
 });
 
 test("order queue prefixes the sort key and does not double it", async () => {
@@ -574,37 +753,64 @@ test("market session takes no arguments and is cached", async () => {
 
 /* ============================= batch and market prices ============================= */
 
-test("batch prices join the symbols and report which ones came back", async () => {
-  responder = () => ({
-    data: [
-      { symbol: "BBRI", last: 4250 },
-      { symbol: "TLKM", last: 3010 },
-    ],
-  });
-  const batch = await getPricesBatch(["bbri", "TLKM", "asii", "BBRI"]);
+test("prices_batch sends the ONE symbol and reads the numeric series", async () => {
+  // The measured payload: bare numbers under `data.prices`, not records. locateRows looks for
+  // arrays of RECORDS and correctly declines to bind this, so without the series field the result
+  // was `rows: []` / `dataPath: null` — indistinguishable from "this symbol has no prices".
+  responder = () => ({ data: { prices: [3280, 3290, 3300] } });
+  const batch = await getPricesBatch(["bbri"]);
 
   const url = lastUrl("/company-price-feed/prices");
   assert.equal(url.pathname, "/company-price-feed/prices");
-  assert.deepEqual(query(url), ["stock_code=BBRI,TLKM,ASII"], "de-duplicated, uppercased, joined");
-  assert.deepEqual(batch.requested, ["BBRI", "TLKM", "ASII"]);
-  assert.deepEqual(batch.found, ["BBRI", "TLKM"]);
-  // The failure this exists to make visible: a wrong multi-value encoding answers 200 with fewer
-  // rows than asked for, and without this the short list looks like a complete answer.
-  assert.deepEqual(batch.missing, ["ASII"]);
-  assert.equal(batch.dataPath, "data");
-  assert.equal(batch.rows.length, 2);
+  assert.deepEqual(query(url), ["stock_code=BBRI"], "uppercased, and one symbol only");
+  assert.deepEqual(batch.requested, ["BBRI"]);
+  assert.deepEqual(batch.series, [3280, 3290, 3300]);
+  assert.equal(batch.seriesPath, "data.prices");
+  assert.equal(batch.dataPath, null, "there are no records here, and pretending otherwise would lie");
+  // A series came back for the one symbol asked for, so it is not missing.
+  assert.deepEqual(batch.missing, []);
 });
 
-test("batch prices find the ticker whatever key it lives under", async () => {
+test("a numeric series is distinguished from a genuinely empty answer", async () => {
+  // The distinction this whole field exists for. Same `rows: []` in both cases; different meaning.
+  responder = () => ({ data: { prices: [] } });
+  const empty = await getPricesBatch(["BBRI"]);
+  assert.equal(empty.series, null, "an empty array is not a series");
+  assert.deepEqual(empty.missing, ["BBRI"], "nothing came back, so the symbol is unanswered");
+});
+
+test("prices_batch refuses more than one symbol, because this route does not batch", async () => {
+  // Settled 2026-09-01: comma-joining returns an EMPTY list and the repeated-key form answers
+  // 400 "too many values for field stock_code". Sending it anyway would return an empty result
+  // that reads as "these symbols have no prices" — a claim about the market, not the request.
+  await assert.rejects(
+    () => getPricesBatch(["BBRI", "TLKM"]),
+    (err: unknown) => err instanceof StockbitError && /takes ONE symbol/.test(err.message),
+  );
+  await assert.rejects(
+    () => getPricesBatch(["BBRI", "TLKM", "ASII"]),
+    (err: unknown) => err instanceof StockbitError && err.kind === "invalid_param",
+  );
+  assert.equal(requests, 0, "refused locally, without a round trip");
+});
+
+test("prices_batch de-duplicates before counting, so one symbol twice is still one symbol", async () => {
+  responder = () => ({ data: { prices: [3280] } });
+  const batch = await getPricesBatch(["bbri", "BBRI"]);
+  assert.deepEqual(batch.requested, ["BBRI"]);
+  assert.deepEqual(query(lastUrl("/company-price-feed/prices")), ["stock_code=BBRI"]);
+});
+
+test("prices_batch finds the ticker whatever key it lives under", async () => {
   // The key the symbol arrives under has not been observed, so matching is on values, not names.
   responder = () => ({ data: { result: [{ code: "bbri", price: "4,250" }] } });
-  const batch = await getPricesBatch(["BBRI", "TLKM"]);
+  const batch = await getPricesBatch(["BBRI"]);
   assert.deepEqual(batch.found, ["BBRI"]);
-  assert.deepEqual(batch.missing, ["TLKM"]);
+  assert.deepEqual(batch.missing, []);
   assert.equal(batch.dataPath, "data.result");
 });
 
-test("batch prices keep the payload when no rows can be located", async () => {
+test("prices_batch keeps the payload when no rows can be located", async () => {
   responder = () => ({ data: { message: "no data" } });
   const batch = await getPricesBatch(["BBRI"]);
   assert.deepEqual(batch.rows, []);
@@ -613,69 +819,43 @@ test("batch prices keep the payload when no rows can be located", async () => {
   assert.deepEqual(batch.raw, { message: "no data" });
 });
 
-test("batch prices refuse an empty or oversized list before the wire", async () => {
+test("prices_batch refuses an empty list before the wire", async () => {
   await assert.rejects(
     () => getPricesBatch([]),
     (err: unknown) => err instanceof StockbitError && err.kind === "invalid_param",
   );
-  const many = Array.from({ length: PRICES_BATCH_MAX + 1 }, (_, i) => `SYM${i}`);
-  await assert.rejects(
-    () => getPricesBatch(many),
-    (err: unknown) => err instanceof StockbitError && /at most 50/.test(err.message),
-  );
   assert.equal(requests, 0);
 });
 
-test("the batch cache key follows the symbol list", async () => {
-  await getPricesBatch(["BBRI", "TLKM"]);
-  await getPricesBatch(["BBRI", "TLKM"]);
-  assert.equal(requests, 1);
+test("the prices_batch cache key follows the symbol", async () => {
   await getPricesBatch(["BBRI"]);
-  assert.equal(requests, 2, "a different symbol list is a different answer");
+  await getPricesBatch(["BBRI"]);
+  assert.equal(requests, 1);
+  await getPricesBatch(["TLKM"]);
+  assert.equal(requests, 2, "a different symbol is a different answer");
 });
 
-test("market prices validate the date and pass boards through unprefixed", async () => {
-  await getMarketPrices({ symbol: "bbri", date: "2026-08-03", boards: ["reguler", "NEGO"] });
-  const url = lastUrl("/market");
-  assert.equal(url.pathname, "/company-price-feed/prices/BBRI/market");
-  assert.equal(url.searchParams.get("date"), "2026-08-03");
-  // No MARKET_BOARD_ / MARKET_TYPE_ prefix is added: this repo carries two incompatible board
-  // vocabularies already and which, if either, applies here is unknown.
-  assert.deepEqual(url.searchParams.getAll("boards"), ["REGULER", "NEGO"]);
-});
+/* --------------------------------- market prices --------------------------------- */
 
-test("market prices omit date and boards when they were not given", async () => {
-  await getMarketPrices({ symbol: "BBRI" });
-  assert.deepEqual(query(lastUrl("/market")), []);
-});
-
-test("a bad date or board is refused before the wire", async () => {
-  for (const date of ["2026/08/03", "20260803", "2026-02-30"]) {
-    await assert.rejects(
-      () => getMarketPrices({ symbol: "BBRI", date }),
-      (err: unknown) => err instanceof StockbitError && err.kind === "invalid_param",
-      date,
-    );
-  }
+test("price_market refuses without a request, because the route cannot be called", async () => {
+  // Measured 2026-09-01: /company-price-feed/prices/:symbol/market answers 400 with NO parameters
+  // at all, and with every board spelling and parameter name tried. A bare call being refused is
+  // what settles it — if sending nothing is also an error, no argument combination is the fix.
   await assert.rejects(
-    () => getMarketPrices({ symbol: "BBRI", boards: ["reguler; drop"] }),
-    (err: unknown) => err instanceof StockbitError && err.kind === "invalid_param",
+    () => getMarketPrices({ symbol: "BBRI" }),
+    (err: unknown) => err instanceof StockbitError && /cannot be called/.test(err.message),
+  );
+  assert.equal(requests, 0, "no round trip is spent to be told the request is invalid");
+});
+
+test("price_market names orderbook as the thing that actually answers", async () => {
+  // The workaround is the point of the refusal: orderbook.market_data[] already carries the
+  // per-board split, so a caller is redirected rather than left with a dead tool.
+  await assert.rejects(
+    () => getMarketPrices({ symbol: "BBRI", date: "2026-08-03", boards: ["REGULER"] }),
+    (err: unknown) => err instanceof StockbitError && /orderbook/.test(err.message),
   );
   assert.equal(requests, 0);
-});
-
-test("the market-prices cache key includes the symbol, the date and the boards", async () => {
-  await getMarketPrices({ symbol: "BBRI", date: "2026-08-03" });
-  await getMarketPrices({ symbol: "BBRI", date: "2026-08-03" });
-  assert.equal(requests, 1);
-  // The symbol is a path segment, not a query parameter — a key built only from the query would
-  // serve BBRI's session to a caller asking about TLKM.
-  await getMarketPrices({ symbol: "TLKM", date: "2026-08-03" });
-  assert.equal(requests, 2);
-  await getMarketPrices({ symbol: "BBRI", date: "2026-08-04" });
-  assert.equal(requests, 3);
-  await getMarketPrices({ symbol: "BBRI", date: "2026-08-04", boards: ["NEGO"] });
-  assert.equal(requests, 4);
 });
 
 

--- a/test/relogin.test.ts
+++ b/test/relogin.test.ts
@@ -15,7 +15,7 @@
  */
 import { mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 process.env.STOCKBIT_FORCE_FILE_STORE = "1";
 process.env.STOCKBIT_STORE_DIR = mkdtempSync(join(tmpdir(), "stockbit-relogin-"));
@@ -624,7 +624,13 @@ test("only the MCP server arms recovery — batch and the CLIs cannot", () => {
       return entry.name.endsWith(".ts") ? [full] : [];
     });
   for (const file of [...walk(join(ROOT, "src")), ...walk(join(ROOT, "bin"))]) {
-    const rel = file.slice(ROOT.length);
+    // Separators normalised BEFORE anything reads this path, and that is load-bearing rather than
+    // cosmetic. `slice` leaves a native path, so on Windows `rel` was `src\auth\relogin.ts` and the
+    // `endsWith("auth/relogin.ts")` guard below did not match — the DEFINITION escaped its own
+    // exclusion and was reported as a caller. A security property that pins "exactly one file arms
+    // this" was therefore failing on Windows for a reason that had nothing to do with the property,
+    // which is the worst kind of red: it trains a reader to ignore the test.
+    const rel = file.slice(ROOT.length).split(sep).join("/");
     // The definition itself, not a call.
     if (rel.endsWith("auth/relogin.ts")) continue;
     if (/\barmAutoRelogin\s*\(/.test(readFileSync(file, "utf8"))) callers.push(rel);

--- a/test/relogin.test.ts
+++ b/test/relogin.test.ts
@@ -541,10 +541,12 @@ test("a TRANSPORT failure is never reclassified as an auth failure", async () =>
 });
 
 test("a Stockbit 5xx never triggers the destructive advice", async () => {
-  // `refreshOnce` labels EVERY non-ok status on the refresh route `auth` — its ternary picks the
-  // message, not the kind — so a 502 arrives at the escalation looking exactly like a refusal. The
-  // kind test alone therefore let a partial outage, which clears by itself, be answered with
-  // "sign your browser out of Stockbit". Only 401/403 means a credential was refused.
+  // `refreshOnce` used to label EVERY non-ok status on the refresh route `auth` — its ternary picks
+  // the message, not the kind — so a 502 arrived at the escalation looking exactly like a refusal,
+  // and the kind test alone let a partial outage, which clears by itself, be answered with "sign
+  // your browser out of Stockbit". P7g fixed the label at the source, so this now holds twice over:
+  // the kind is `upstream` AND the status is not 401. Both belts are asserted below, because the
+  // escalation must stay wrong-proof if either one is ever loosened.
   armAutoRelogin();
   process.env.STOCKBIT_AUTO_RELOGIN = "1";
   getStore("main").set(jwt(2_000_000_000, "stored"));
@@ -561,6 +563,7 @@ test("a Stockbit 5xx never triggers the destructive advice", async () => {
     );
     assert.ok(err instanceof StockbitError);
     assert.equal(err.status, 502);
+    assert.equal(err.kind, "upstream", "a 5xx on the refresh route is an outage, not a refusal");
     assert.doesNotMatch(err.message, /switch_account/, "an outage is not a reason to sign the user out");
     assert.doesNotMatch(err.message, /signs that browser profile out/i);
   } finally {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -371,9 +371,6 @@ const OBSERVED = [
   // refused, and the single-symbol numeric series read off a real response. Which key a ticker
   // sits under is still unsettled and the description says so in those words.
   "prices_batch",
-  // calendar_today: the multi-bucket payload was captured whole, including the empty-first-bucket
-  // trap that made it report rows: [] while 19 rows sat unread.
-  "calendar_today",
   "stream_trending",
   "brokers",
   "broker_top",
@@ -492,6 +489,10 @@ const PROJECTED = [
   "market_session",
   "price_market",
   "broker_activity",
+  // Its no-argument form WAS measured live on 2026-09-01 and its bucket reader was fixed from that
+  // capture — but `date` and `from`/`to` were not, and the code keeps a flat-shape branch for them.
+  // Same grading `shareholding` got for the same reason: one settled mode is not a settled tool.
+  "calendar_today",
   "stock_conversion",
   "underwriters",
   "screener_run",

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -360,6 +360,20 @@ test("every order-entry write is in the list the instructions page measures agai
  * ------------------------------------------------------------------ */
 
 const OBSERVED = [
+  // Promoted 2026-09-01 by live calls after the ~18:00 WIB broker release. Each earned it on the
+  // repo's own bar — rows came back AND every field the tool names was read out of them — not on
+  // "the route answered". See docs/PENDING-VERIFICATION.md, "Probed live on 2026-09-01".
+  //
+  // market_movers: all eight mover_type members echoed back verbatim against a control value that
+  // 400s, and every projected key read off a real mover_list row.
+  "market_movers",
+  // prices_batch: the ROUTE's behaviour was measured — every multi-symbol encoding tried and
+  // refused, and the single-symbol numeric series read off a real response. Which key a ticker
+  // sits under is still unsettled and the description says so in those words.
+  "prices_batch",
+  // calendar_today: the multi-bucket payload was captured whole, including the empty-first-bucket
+  // trap that made it report rows: [] while 19 rows sat unread.
+  "calendar_today",
   "stream_trending",
   "brokers",
   "broker_top",
@@ -473,14 +487,11 @@ const PROJECTED = [
   "ownership_composition",
   "running_trade",
   "trade_book",
-  "market_movers",
   "top_stocks",
   "order_queue",
   "market_session",
-  "prices_batch",
   "price_market",
   "broker_activity",
-  "calendar_today",
   "stock_conversion",
   "underwriters",
   "screener_run",


### PR DESCRIPTION

---

## What this is

Two deliverables and one piece of carried-over debt:

- **`market_movers` now reaches every view Stockbit's own Movers dialog shows.**
- **The twelve items still carrying work from the 2026-08-31 tool report are closed** — each either
  fixed, or answered with a measured statement of what the endpoint will not do.
- **The three auth items PR #17 wrote down and deferred are closed**, including a hole in a safety
  property that shipped.

Everything below was settled by live calls against a real account on **2026-09-01, ~18:15–18:55
WIB** — deliberately after the ~18:00 broker release on a trading day, because that is the only
window in which the staleness questions can be answered at all. Every measurement is transcribed in
`docs/PENDING-VERIFICATION.md`.

## The eight movers views, and why the vocabulary can be trusted

`/order-trade/market-mover` echoes `mover_type` back, so a value that returns as what was sent was
accepted. On its own that proves little — this API's characteristic failure is answering 200 with
its default. So the vocabulary was settled **against a control**: `MOVER_TYPE_DEFINITELY_NOT_REAL`
answers **400**. This endpoint rejects members it does not know, which is what turns the echo into
evidence.

Eight members accepted, each echoed verbatim:

`topGainer` · `topLoser` · `topValue` · `topVolume` · `topFrequency` · `netForeignBuy` ·
`netForeignSell` · `bigMoneyNetValue`

The result reports the **echo** as `view` — what the server says it served — never what was
requested. Fifteen near-miss spellings were refused and are recorded so nobody re-guesses them.

**The dialog's ninth tab, IEP/IEV, is deliberately not an enum member.** Ten spellings of it were
refused. It is a *field*: `iepiev_detail` rides on every row of every view, and is projected as
`iepIev` with a note that it only means anything during pre-opening (08:45–09:00 WIB). Shipping it
as a member would have told callers the server accepts a value nobody has seen it accept — which is
the `topGainer`/`topgainer` bug again.

Rows come from `data.mover_list` with `readFrom` naming each wire key, `unmappedKeys` for what the
projection does not recognise, and the raw row kept. Figures arrive as `{raw, formatted}` and are
read with `readRaw` — reading them with `Number()` once produced `NaN` for 100 symbols and looked
like a dead market.

`limit` is honoured and capped at 50 by the service. `page` is ignored. The payload's own
`pagination` block reads all zeros on **every** call, including truncated ones, so it is **not**
projected: a `has_next: false` that is always false is not an answer about whether more rows exist.

## Two corrections to the source report

Both are places its inference outran its evidence, and both were checked rather than assumed.

**D5 is not a sort bug.** The hotlist returned the *same nine symbols* at `limit` 5, 25, 50 and 100
— it ignores `limit` — so a contiguous descending run of nine changes is exactly what a correct sort
over a nine-symbol universe looks like. There was nothing to re-sort. `top_movers` keeps its name
and now states its real universe; `market_movers` is the market-wide surface. For the same moment
the hotlist served 9 rows and `market-mover` served 50, including structured warrants — genuinely
different universes.

**D12's three "dead fields" are alive.** The report records `net_value`, `buy_value` and
`sell_value` as `"0"` on every row and asks for them to be reported absent. On this reading all
three carry **89 distinct values**. They are projected normally. Whatever produced the zeroes was
not the schema.

## R1 / R2 / R3 reclassified: not staleness

Measured after the broker release on the same trading day, all three serve **today**:

| Route | What it said |
|---|---|
| `runningTrade` | `data.date = "2026-09-01"` |
| `broker_flow_intraday` | `from` = `to` = `"2026-09-01"` |
| `market_movers` | `net_foreign_updated_at = "2026-09-01"`, and `is_show_net_foreign` **true** |

The field report saw `is_show_net_foreign: false` intraday. Observing both sides of that flip is
what settles it: the data is correct and simply unpublished until ~18:00 WIB. These are
**documentation** items — payloads that fail to announce which session they are from — not bugs.

So `price_bands` now carries an explicitly **null** `dataAsOf` with a note. Null on purpose: the
orderbook payload has no date, and fetching one from `market_movers` to fill it in would attribute
one route's date to another route's numbers, which is inventing a date with extra steps.

## The other report items

- **D13 — `calendar_today` reported "no corporate actions today" while the response carried 19.**
  The reader took the first array-valued key and the payload is buckets whose first bucket (`bonus`)
  is empty, so a day holding a dividend, eight economic events, a RUPS and nine warrants read as
  nothing. Every bucket is now returned tagged with its kind, and `date` comes from the response's
  own `today`.
- **D11 — `broker_activity` sent a `period` the endpoint refuses.** All ten `TB_PERIOD_*` members
  answer 400 here, *including the one its sibling `broker_distribution` accepts* — that control is
  what settles it. Unknown keys are silently ignored, so the 400 is a validated field refusing a
  value, not an unknown parameter. It is no longer sent, and `broker_activity_transaction` joins the
  row containers so the tool stops reporting `count: 0` beside a `dataKeys` naming the container the
  rows were in.
- **D12 — `broker_top` put the biggest broker last.** Rows arrive **ascending** by `total_value` and
  `limit` is ignored, so a tool documented as "which brokers moved the most" led with the smallest
  of 89. Sorted descending client-side, and said so.
- **D7 — `prices_batch` does not batch.** Comma-joining returns an empty list; the repeated-key form
  the report proposed is a hard `400 too many values for field "stock_code"`. The route takes one
  symbol and returns a price *series*. More than one is now refused locally rather than sent to come
  back empty — an empty list reads as a claim about the market when the truth is a claim about the
  request.
- **D9 — `price_market` cannot be called at all.** It answers 400 with **no** query parameters,
  which is what settles it: if sending nothing is also an error, no argument combination is the fix.
  Earlier passes read these 400s as an unknown board vocabulary and kept guessing spellings; the
  missing control was the empty request. It now refuses and names `orderbook.market_data[]`.
- **D10 — the `raw: true` escape hatch read a different endpoint from the one it diagnoses.** It
  called `/charts/:symbol` while the projection reads `/charts/:symbol/daily`, and the two do not
  share a vocabulary: the first refuses `1w` outright and answers `{chart_points: []}` for
  everything else. That explains both symptoms — `1w` erroring and `1m` coming back empty — as the
  route being wrong rather than the value.
- **Units.** `orderbook.volume` is SHARES while `technicals.volumeLots` is LOTS, reconciling ×100,
  in a payload that also labels its depth figures `lot` beside a `volume` in shares. Named on the
  tool.

**New, and not in the report:** `broker_flow_intraday`'s `data_last_updated` is stamped `Z` but the
value is WIB — the 2026-09-01 reading was five hours in the future. Anything parsing it as UTC gets
the wrong instant.

## The auth debt (P7g)

**`stockbit-auth login` drove the shared browser profile without taking `login.lock`.** Gate 5 of
automatic recovery is "`login.lock` must be free", so it read *free* for the whole time a CLI login
was open — and an unattended recovery could launch a second browser onto the profile where someone
was at that moment typing their password. The MCP tool's own comment names the CLI as the thing the
lock protects against, and the CLI was the one participant that did not take it. The documented cost
of that collision is eleven orphaned browser processes and a `SingletonLock` that blocked every
later login.

The staleness budget moved to a new `src/auth/loginlock.ts` rather than becoming a third hand-kept
copy. The refusal *message* deliberately stays at each call site — each names a different likely
holder and a different next step.

**A regression this branch introduced, and caught.** The first version released the lock only from a
`process.once("exit")` listener. Node does **not** run those when a signal terminates the process —
measured, not assumed. So Ctrl-C during the fifteen-minute browser login leaked the lock and refused
every login, CLI and MCP and recovery alike, for twenty minutes. Before the CLI took a lock at all,
Ctrl-C cost nothing; taking a lock is only an improvement if releasing it is at least as reliable as
never having taken it. SIGINT and SIGTERM now release and re-raise with the default disposition, so
the exit status is still the signal's. **The test was verified by mutation** — removing the handlers
fails it on exactly the assertion it names.

**`refreshOnce` labelled every non-ok refresh `kind: "auth"`,** so a 502 was indistinguishable from a
revoked session. It now routes through `kindForStatus`, which already encoded that rule — rather
than a second copy of it. Both call sites that branch on the kind were read and decided
deliberately, with a test per status class, because getting this wrong means a network blip telling
the user to log in again.

**ADR-0011 now claims exactly what has been observed.** The recovery path was *attempted* against a
live account for this PR: the stored credential was killed, the built server armed, and the quote
**answered in 0.3 s without opening anything**. `ensureFresh` adopts the browser's own access token
before any refresh, so a dead stored credential produces no 401 while the browser session is alive.
Firing this path needs three things at once — a rejected stored token, a web-session ACCESS token
aged out so that level declines, and a web-session REFRESH token still alive because gate 4 tests
exactly that. That is ordinary in the wild and awkward to stage, which is the honest reason nobody
has watched it run. It stays **Projected**, now with a reason rather than an absence, and the ~3 s
figure stays attributed to a field report.

## Evidence changes

Three tools move on the ladder, and the hand-written map in `test/tools.test.ts` is updated to
match:

- `market_movers` → **observed** (every member echoed, every projected key read off a real row)
- `prices_batch` → **observed** for the route's behaviour; the one unsettled detail (which key a
  ticker sits under) is caveated in words the registration cross-check cannot read as a whole-tool
  claim
- `calendar_today` → stays **projected**. It was briefly promoted and demoted again during review:
  only its no-argument form was measured, `date` and `from`/`to` were not, and the code keeps a
  flat-shape branch for them. `shareholding` stayed projected for exactly this reason.

## How this was checked

Three file-disjoint implementation lanes, then **nine adversarial reviewers** across them with
distinct lenses (correctness, claim honesty, test integrity). Their surviving findings became one
bug-loop round — the SIGINT regression above, a brokers test that never touched the schema it
claimed to test (the fake definer discarded the shape argument, so it passed against a tool that had
dropped the field), `broker_top` asserting units D12 never measured, and a restored NOT-PARSED
sentence whose loss had reintroduced the D13 defect on the other branch.

**Full gate green:**

```
typecheck    clean
test         1936 tests / 1936 pass / 0 fail
build        clean
smoke        default 40 tools, 6 prompts · all 139 tools, 8 prompts
check:pack   163 files (157 compiled, 6 root)
docs:tools   regenerated, not stale
```

Baseline before the first edit was 0 failures; no test was weakened or deleted to get here.

## Invariants

- **Invariant 1 (closed route table)** — untouched. Everything here is a GET, and no new route rows
  were added; the movers work is new *parameters* on an existing row.
- **Invariant 2 (`define.write` never joins the workflow handler map)** — untouched. No new write
  tool; `WRITES` is unchanged.
- **Invariant 3 (no `saveSettings` under `src/tools/`, `src/trading/`, `src/eipo/`)** — untouched.

No order-entry, e-IPO, or confirmation-gate code is in this diff.

## Deliberately not done

- **`market_movers` is not in `CORE_TOOLS`.** That list is at exactly 40 and `CORE_CAP` is 40, so
  adding it would breach the documented default-surface size — a larger change than this PR's scope.
  `top_movers`' description points at it instead, so a core-profile user is told where the
  market-wide ranking lives. Happy to raise the cap in a follow-up if that is wanted.
- **The open-session half of P7a.** D6's lag confirmation and the intraday behaviour of
  `is_show_net_foreign` need 09:00–16:00 WIB. The closed-market half of D5 was settled instead and
  is decisive on its own.
- **P7f, the live tail (D2 remainder).** P4 established the tape cannot reach it at any argument;
  this stays a research item rather than a fix.

---

## Windows CI, which was already red on `main`

Worth separating, because two of the three failures are not this branch's.

`main` at `7037e43` fails `windows-latest · node 22` and `node 24`, on two tests, and both are
**path-separator bugs in source scans** rather than anything about the behaviour they guard:

- `chartbit.test.ts` compared a native path (`chartbit\driver.ts`) against a literal written with a
  forward slash, and failed on a property that was perfectly true.
- `relogin.test.ts` was worse than cosmetic. It excludes the definition of `armAutoRelogin` with
  `rel.endsWith("auth/relogin.ts")`, which does not match `src\auth\relogin.ts` — so on Windows the
  definition escaped its own exclusion and was reported as a *second* caller. A test whose whole job
  is to pin "exactly one file arms recovery" was failing for a reason unrelated to that property,
  which is the kind of red that teaches a reader to ignore the test.

Both now normalise separators before anything reads the path. The assertion is about *which file*,
never about how an OS spells one.

**The third failure was mine**, and it took two goes:

- The Windows `skip` on the new Ctrl-C test was passed **after** the callback. node's signature is
  `test(name, options, fn)`, so it parsed fine and did nothing — the skip shipped as decoration and
  Windows failed on exactly the assertion it existed to prevent. Fixed, and this time verified by
  forcing the condition true and watching the runner report it skipped, with the reason.
- The test also **raced the code it tests**. It polled for `login.lock` to appear and fired SIGINT
  immediately, but `holdLoginLock` creates that directory inside `acquireLoginLock()` and registers
  the handlers a few statements later — so the lock exists slightly before they are installed. That
  passed when the file ran alone and failed under the loaded machine of a full suite run. It now
  synchronises on the child's own "Opening a browser" line, which prints only after
  `holdLoginLock` has returned.

The skip is about the **simulation, not the fix**: a real console Ctrl-C on Windows does deliver
SIGINT and does run the handler, so the lock is released there too. `child.kill("SIGINT")` on
Windows terminates the process outright instead, so Ctrl-C cannot be simulated. SIGTERM is
separately a no-op on Windows and nothing here can improve that.

**CI on this branch is now green on all six matrix jobs**, including the two Windows ones that were
failing before it.
