### PR TITLE
fix(ci): ask the MCP Registry before publishing, as the npm half already did

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -316,7 +316,71 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Pinned for the same reason `decide` pins it: this job now runs
+      # `scripts/mcp-registry-version-state.mjs`, which uses global `fetch` and
+      # `AbortSignal.timeout`. The runner's default Node is not part of this repository's contract.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      # ASK BEFORE PUBLISHING — the same question the npm half of this pipeline has always asked,
+      # and the half that was missing. Both workflows reach a `registry` job for the SAME version
+      # (see the concurrency note at the top of this file), so the second one to arrive re-published
+      # what the first had just published and was refused:
+      #
+      #   Error: publish failed: server returned status 400: {"errors":[{"message":"invalid version:
+      #   cannot publish duplicate version"}]}
+      #
+      # A red run reporting a failure that had already succeeded. `server.json` is read rather than
+      # `needs.decide.outputs.version` because `server.json` is the document `mcp-publisher` sends —
+      # asking about anything else would be asking about a version this step is not publishing.
+      # `test/distribution.test.ts` pins the two equal, so this is also the package version.
+      #
+      # UNDETERMINED DOES NOT SKIP. This is the deliberate opposite of the npm gate, because the
+      # costs are mirror images: there a wrong answer publishes something irreversible, here a wrong
+      # `present` silently omits a version from the registry — the "silent no-op" this workflow
+      # exists to forbid. A needless re-attempt costs one refused request, so anything short of a
+      # definite `present` publishes, and the duplicate tolerance below catches it.
+      - name: Is this version already in the MCP Registry?
+        id: mcp_registry
+        run: |
+          set -euo pipefail
+          published="$(node -p "require('./server.json').version")"
+          server_name="$(node -p "require('./server.json').name")"
+          # Validate BEFORE it reaches $GITHUB_OUTPUT, for the reason `decide` spells out above:
+          # that file is parsed as `key=value` lines, so a value carrying a newline defines a SECOND
+          # key of the writer's choosing — here `needed=false`, which would skip the publish and
+          # report success. The character class is what a version may contain and nothing more.
+          case "$published" in
+            "" | *[!0-9A-Za-z.+-]*)
+              echo "::error::server.json version is empty or has characters outside [0-9A-Za-z.+-]. Refusing to use it." >&2
+              exit 1 ;;
+          esac
+          echo "version=$published" >> "$GITHUB_OUTPUT"
+          # Both are passed explicitly rather than left to the script's own default: the script
+          # resolves `server.json` relative to ITSELF while this step reads it relative to the
+          # working directory, and the two would diverge the moment anyone set `working-directory:`
+          # on the job — leaving the annotation naming a version the query never asked about.
+          #
+          # `|| state=""` rather than letting `set -e` end the job: exit 2 means "could not
+          # determine", and the policy above turns that into a publish, not a failure.
+          state="$(node scripts/mcp-registry-version-state.mjs --name "$server_name" --version "$published")" || state=""
+          case "$state" in
+            present)
+              echo "needed=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::$published is already in the MCP Registry. Nothing to publish." ;;
+            absent)
+              echo "needed=true" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "needed=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::could not determine whether $published is in the MCP Registry (reason above). Publishing anyway — a duplicate is refused harmlessly and tolerated." ;;
+          esac
+
+      # Downloaded only when there is something to publish. When the check above says the version is
+      # already there this job has nothing left to do, and spending a github.com round trip it can
+      # FAIL on would turn a no-op into a red run — which is the failure this change exists to close.
       - name: Install mcp-publisher
+        if: steps.mcp_registry.outputs.needed == 'true'
         run: |
           set -euo pipefail
           asset="mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz"
@@ -336,7 +400,26 @@ jobs:
       # Publishing to the registry only makes sense once the npm package with the matching `mcpName`
       # is live, which is what `needs: publish` guarantees.
       - name: Publish server.json
+        if: steps.mcp_registry.outputs.needed == 'true'
+        env:
+          MCP_VERSION: ${{ steps.mcp_registry.outputs.version }}
         run: |
           set -euo pipefail
           ./mcp-publisher login github-oidc
-          ./mcp-publisher publish
+
+          # The step above closes the ordinary case. This closes the RACE, which checking harder
+          # cannot: the other workflow can publish in the gap between that query and this command.
+          # The registry's own refusal is the only authority on what is already there, so the ONE
+          # error that means "the end state you asked for already holds" is read as success.
+          # Everything else — a malformed server.json, a rejected OIDC login, an unreachable
+          # registry — still fails the job. The match is on the registry's exact wording rather than
+          # on the 400, which also covers server.json being wrong.
+          if ./mcp-publisher publish 2>&1 | tee /tmp/mcp-publish.log; then
+            exit 0
+          fi
+          if grep -q "cannot publish duplicate version" /tmp/mcp-publish.log; then
+            echo "::notice::$MCP_VERSION reached the MCP Registry from the other workflow while this job was running. Treating as published."
+            exit 0
+          fi
+          echo "::error::mcp-publisher failed for a reason other than a duplicate version. The log is above." >&2
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,70 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Pinned for the same reason the job above pins it: this job now runs
+      # `scripts/mcp-registry-version-state.mjs`, which uses global `fetch` and
+      # `AbortSignal.timeout`. The runner's default Node is not part of this repository's contract.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      # ASK BEFORE PUBLISHING — the same question the npm step in the job above has always asked,
+      # and the half of the pipeline that was missing it. THIS workflow is the one that observed the
+      # failure. `npm version <bump> && git push --follow-tags` starts publish.yml and release.yml
+      # together; the shared concurrency group serialises them; publish.yml gets there first and
+      # publishes to both registries; this workflow then correctly SKIPS the npm publish, still
+      # succeeds, and its `registry` job — which asked nothing — re-published and was refused:
+      #
+      #   Error: publish failed: server returned status 400: {"errors":[{"message":"invalid version:
+      #   cannot publish duplicate version"}]}
+      #
+      # `server.json` is read rather than the tag or package.json because `server.json` is the
+      # document `mcp-publisher` sends; `test/distribution.test.ts` pins all three equal.
+      #
+      # UNDETERMINED DOES NOT SKIP, the deliberate opposite of the npm gate above. There a wrong
+      # answer publishes something irreversible; here a wrong `present` silently omits a version
+      # from the registry, which is the failure mode this pipeline is written to forbid. A needless
+      # re-attempt costs one refused request, so anything short of a definite `present` publishes.
+      - name: Is this version already in the MCP Registry?
+        id: mcp_registry
+        run: |
+          set -euo pipefail
+          published="$(node -p "require('./server.json').version")"
+          server_name="$(node -p "require('./server.json').name")"
+          # Validate BEFORE it reaches $GITHUB_OUTPUT, for the reason publish.yml's `decide` job
+          # spells out: that file is parsed as `key=value` lines, so a value carrying a newline
+          # defines a SECOND key of the writer's choosing — here `needed=false`, which would skip
+          # the publish and report success. The character class is what a version may contain.
+          case "$published" in
+            "" | *[!0-9A-Za-z.+-]*)
+              echo "::error::server.json version is empty or has characters outside [0-9A-Za-z.+-]. Refusing to use it." >&2
+              exit 1 ;;
+          esac
+          echo "version=$published" >> "$GITHUB_OUTPUT"
+          # Both are passed explicitly rather than left to the script's own default: the script
+          # resolves `server.json` relative to ITSELF while this step reads it relative to the
+          # working directory, and the two would diverge the moment anyone set `working-directory:`
+          # on the job — leaving the annotation naming a version the query never asked about.
+          #
+          # `|| state=""` rather than letting `set -e` end the job: exit 2 means "could not
+          # determine", and the policy above turns that into a publish, not a failure.
+          state="$(node scripts/mcp-registry-version-state.mjs --name "$server_name" --version "$published")" || state=""
+          case "$state" in
+            present)
+              echo "needed=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::$published is already in the MCP Registry — publish.yml got here first. Skipping the publish." ;;
+            absent)
+              echo "needed=true" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "needed=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::could not determine whether $published is in the MCP Registry (reason above). Publishing anyway — a duplicate is refused harmlessly and tolerated." ;;
+          esac
+
+      # Downloaded only when there is something to publish. When the check above says the version is
+      # already there this job has nothing left to do, and spending a github.com round trip it can
+      # FAIL on would turn a no-op into a red run — which is the failure this change exists to close.
       - name: Install mcp-publisher
+        if: steps.mcp_registry.outputs.needed == 'true'
         run: |
           set -euo pipefail
           asset="mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz"
@@ -189,7 +252,26 @@ jobs:
       # `mcpName` is live — the only precondition the MCP Registry has. Gating on the token instead
       # used to skip this silently for a version publish.yml had already put on npm.
       - name: Publish server.json
+        if: steps.mcp_registry.outputs.needed == 'true'
+        env:
+          MCP_VERSION: ${{ steps.mcp_registry.outputs.version }}
         run: |
           set -euo pipefail
           ./mcp-publisher login github-oidc
-          ./mcp-publisher publish
+
+          # The step above closes the ordinary case. This closes the RACE, which checking harder
+          # cannot: publish.yml can publish in the gap between that query and this command. The
+          # registry's own refusal is the only authority on what is already there, so the ONE error
+          # that means "the end state you asked for already holds" is read as success. Everything
+          # else — a malformed server.json, a rejected OIDC login, an unreachable registry — still
+          # fails the job. The match is on the registry's exact wording rather than on the 400,
+          # which also covers server.json being wrong.
+          if ./mcp-publisher publish 2>&1 | tee /tmp/mcp-publish.log; then
+            exit 0
+          fi
+          if grep -q "cannot publish duplicate version" /tmp/mcp-publish.log; then
+            echo "::notice::$MCP_VERSION reached the MCP Registry from publish.yml while this job was running. Treating as published."
+            exit 0
+          fi
+          echo "::error::mcp-publisher failed for a reason other than a duplicate version. The log is above." >&2
+          exit 1

--- a/scripts/mcp-registry-version-state.mjs
+++ b/scripts/mcp-registry-version-state.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+/**
+ * Is this exact version already in the MCP Registry?
+ *
+ * The sibling of `scripts/npm-version-state.mjs`, for the other registry this project publishes to,
+ * and it exists because only half the release pipeline had ever been made idempotent.
+ *
+ * The npm half asks "is this version already published?" before acting, so a re-run, or the second
+ * of two concurrent workflows, correctly does nothing. The MCP Registry half asked nothing: both
+ * `publish.yml` and `release.yml` ran `mcp-publisher publish` unconditionally. Observed in
+ * production on v1.3.0:
+ *
+ *     Error: publish failed: server returned status 400: {"title":"Bad Request","status":400,
+ *     "detail":"Failed to publish server","errors":[{"message":"invalid version: cannot publish
+ *     duplicate version"}]}
+ *
+ * — a RED run reporting a failure that had in fact already succeeded, minutes earlier, from the
+ * other workflow. `npm version <bump> && git push --follow-tags` delivers the commit and the tag in
+ * one push with the user's credential, so both workflows start; the shared concurrency group
+ * serialises them; the first publishes; the second re-publishes and is refused.
+ *
+ * The contract is the sibling's, deliberately, so the two read the same way:
+ *
+ *   stdout `present` + exit 0 — the registry answered, and this version is there.
+ *   stdout `absent`  + exit 0 — the registry answered, and this version is not there.
+ *   exit 2 + stderr           — COULD NOT DETERMINE. Never, for any reason, invented as either.
+ *
+ * What the CALLER does with the third outcome is where the two part company, and the reason is that
+ * the costs are mirror images:
+ *
+ *   - For npm, a wrong `absent` publishes something irreversible. So there, undetermined must never
+ *     reach the publish, and `set -e` on exit 2 fails the job.
+ *   - Here, a wrong `present` SKIPS, and a version silently missing from the registry is the exact
+ *     "silent no-op" `publish.yml` is written to forbid. A wrong `absent` merely re-attempts a
+ *     publish the registry itself refuses, which costs nothing. So the workflows treat undetermined
+ *     as "go ahead and try", and the registry's own duplicate refusal is the backstop.
+ *
+ * Two facts about the endpoint, both established by querying it rather than by reading about it:
+ *
+ *   1. `search` is a SUBSTRING match, not an exact one. `io.github.someone/stockbit-mcp` would match
+ *      a query for `stockbit-mcp`. So a hit only counts when `server.name` equals the name exactly
+ *      and `server.version` equals the version exactly.
+ *   2. An unknown server and an unknown version both answer HTTP 200 with `{"servers":[],
+ *      "metadata":{"count":0}}` — never a 404. Which is why, unlike the npm sibling, a 404 here is
+ *      NOT "absent": this endpoint has no 404 for a real query, so one means the API moved, and
+ *      that is undetermined.
+ *
+ * Usage:
+ *   node scripts/mcp-registry-version-state.mjs [--name <name>] [--version <version>]
+ *                                               [--registry <url>] [--response-file <path>]
+ *                                               [--retries <n>] [--timeout <ms>]
+ *
+ * `--name` and `--version` default to `server.json` — not `package.json`, because `server.json` is
+ * the document `mcp-publisher` actually publishes and it carries its own `version` field.
+ */
+import { readFileSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+/** The two answers that mean "the registry told me". Both exit 0. */
+export const PRESENT = "present";
+export const ABSENT = "absent";
+
+/**
+ * The third outcome. Anything that is not a definite present/absent answer throws this, and the CLI
+ * turns it into exit 2 — deliberately not exit 1, so a caller can tell it apart from a shell error.
+ */
+export class UndeterminedError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.name = "UndeterminedError";
+  }
+}
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_REGISTRY = "https://registry.modelcontextprotocol.io";
+
+/**
+ * Statuses where the registry is reachable but momentarily unwilling. Retrying these is worthwhile;
+ * retrying a 400 or a 401 is not. 404 is absent from this set on purpose — see the header: it is
+ * not a real answer from this endpoint, so it is undetermined rather than something to retry into.
+ */
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+/** Name and version as `server.json` declares them. */
+export function serverDefaults(root = ROOT) {
+  const path = join(root, "server.json");
+  let server;
+  try {
+    server = JSON.parse(readFileSync(path, "utf8"));
+  } catch (cause) {
+    throw new UndeterminedError(`could not read ${path}`, { cause });
+  }
+  if (server === null || typeof server !== "object" || Array.isArray(server)) {
+    throw new UndeterminedError(`${path} is not an object`);
+  }
+  return { name: server.name, version: server.version };
+}
+
+/**
+ * The query URL for one name at one version.
+ *
+ * Both values are percent-encoded rather than concatenated, so neither can add a parameter of its
+ * own: the name is data here, exactly like the version. `io.github.owner/name` contains a slash,
+ * which is legal inside a query value and must survive as one.
+ */
+export function searchUrl(name, version, registry = DEFAULT_REGISTRY) {
+  const base = `${registry.replace(/\/+$/, "")}/v0/servers`;
+  return `${base}?search=${encodeURIComponent(name)}&version=${encodeURIComponent(version)}`;
+}
+
+function parseBody(text, where) {
+  try {
+    return JSON.parse(text);
+  } catch (cause) {
+    throw new UndeterminedError(`${where} did not return valid JSON`, { cause });
+  }
+}
+
+/**
+ * Decide present/absent from an already-parsed search response.
+ *
+ * An empty `servers` array IS a real answer — the endpoint returns exactly that for a version it
+ * does not have, and for a server it has never heard of. A body with no `servers` ARRAY is not: a
+ * response that omits it is some other document, an error envelope or a moved API, and inferring
+ * "absent" from it would be the fail-open this pair of scripts exists to remove.
+ *
+ * The comparison is exact on both fields because `search` matches substrings, so the array can
+ * legitimately contain a DIFFERENT server whose name merely contains this one's.
+ */
+export function stateFromSearch(body, name, version) {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    throw new UndeterminedError("the registry returned a body that is not a search response object");
+  }
+  const { servers } = body;
+  if (!Array.isArray(servers)) {
+    throw new UndeterminedError("the registry returned a document with no `servers` array");
+  }
+  const hit = servers.some((entry) => {
+    const server = entry === null || typeof entry !== "object" ? undefined : entry.server;
+    if (server === null || typeof server !== "object") return false;
+    return server.name === name && server.version === version;
+  });
+  return hit ? PRESENT : ABSENT;
+}
+
+/**
+ * Ask the registry whether `name@version` is published.
+ *
+ * Resolves to PRESENT or ABSENT. Throws `UndeterminedError` for everything else.
+ */
+export async function mcpRegistryVersionState({
+  name,
+  version,
+  registry = DEFAULT_REGISTRY,
+  responseFile,
+  fetch: fetchImpl = globalThis.fetch,
+  retries = 2,
+  timeoutMs = 15000,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+} = {}) {
+  if (typeof name !== "string" || name === "") {
+    throw new UndeterminedError("no server name to look up");
+  }
+  if (typeof version !== "string" || version === "") {
+    throw new UndeterminedError("no version to look up");
+  }
+
+  // Offline mode, for the tests: a search response read from disk. An unreadable or malformed file
+  // is "could not determine", never a guess in either direction.
+  if (responseFile !== undefined) {
+    let text;
+    try {
+      text = readFileSync(responseFile, "utf8");
+    } catch (cause) {
+      throw new UndeterminedError(`could not read the response file ${responseFile}`, { cause });
+    }
+    return stateFromSearch(parseBody(text, responseFile), name, version);
+  }
+
+  const url = searchUrl(name, version, registry);
+  let lastProblem = `${url} was never reached`;
+
+  for (let attempt = 1; attempt <= retries + 1; attempt += 1) {
+    let response;
+    try {
+      response = await fetchImpl(url, {
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (cause) {
+      // Transport: DNS, TLS, a reset connection, the timeout above. Reported distinctly from "the
+      // registry answered something unexpected" because they need different human responses.
+      lastProblem = `could not reach ${url} (transport failure: ${cause?.message ?? cause})`;
+      if (attempt <= retries) {
+        await sleep(attempt * 1000);
+        continue;
+      }
+      throw new UndeterminedError(lastProblem, { cause });
+    }
+
+    if (response.status === 200) {
+      return stateFromSearch(parseBody(await response.text(), url), name, version);
+    }
+
+    lastProblem = `${url} answered HTTP ${response.status}, and this endpoint answers 200 for every real query`;
+    if (RETRYABLE_STATUS.has(response.status) && attempt <= retries) {
+      await sleep(attempt * 1000);
+      continue;
+    }
+    throw new UndeterminedError(lastProblem);
+  }
+
+  throw new UndeterminedError(lastProblem);
+}
+
+const FLAGS = new Set(["--name", "--version", "--registry", "--response-file", "--retries", "--timeout"]);
+
+/** Flags in either `--flag value` or `--flag=value` form. Unknown flags are a hard error. */
+export function parseArgs(argv) {
+  const options = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const eq = token.indexOf("=");
+    const flag = eq === -1 ? token : token.slice(0, eq);
+    if (!FLAGS.has(flag)) {
+      throw new UndeterminedError(`unknown argument ${JSON.stringify(token)}`);
+    }
+    const value = eq === -1 ? argv[(i += 1)] : token.slice(eq + 1);
+    if (value === undefined) {
+      throw new UndeterminedError(`${flag} needs a value`);
+    }
+    switch (flag) {
+      case "--name":
+        options.name = value;
+        break;
+      case "--version":
+        options.version = value;
+        break;
+      case "--registry":
+        options.registry = value;
+        break;
+      case "--response-file":
+        options.responseFile = value;
+        break;
+      case "--retries":
+      case "--timeout": {
+        const n = Number(value);
+        if (!Number.isFinite(n) || n < 0) {
+          throw new UndeterminedError(`${flag} needs a non-negative number, not ${JSON.stringify(value)}`);
+        }
+        if (flag === "--retries") options.retries = n;
+        else options.timeoutMs = n;
+        break;
+      }
+    }
+  }
+  return options;
+}
+
+/** Returns the process exit code rather than calling `process.exit`, so it is callable from a test. */
+export async function main(argv = process.argv.slice(2), out = process.stdout, err = process.stderr) {
+  try {
+    const options = parseArgs(argv);
+    // The defaults are read only for whichever of name/version the caller did not supply, so a
+    // fully-specified call never needs server.json to exist.
+    const needsDefaults = options.name === undefined || options.version === undefined;
+    const defaults = needsDefaults ? serverDefaults() : {};
+    const state = await mcpRegistryVersionState({ ...defaults, ...options });
+    out.write(`${state}\n`);
+    return 0;
+  } catch (error) {
+    err.write(`mcp-registry-version-state: ${error?.message ?? error}\n`);
+    return 2;
+  }
+}
+
+/**
+ * Run only when invoked as a program. Importing this from a test must not exit the test runner, and
+ * the realpath comparison keeps that true through symlinks and Windows path casing.
+ */
+function invokedDirectly() {
+  try {
+    if (!process.argv[1]) return false;
+    const self = pathToFileURL(realpathSync(fileURLToPath(import.meta.url))).href;
+    return pathToFileURL(realpathSync(process.argv[1])).href === self;
+  } catch {
+    return false;
+  }
+}
+
+if (invokedDirectly()) {
+  process.exitCode = await main();
+}

--- a/test/mcpregistrystate.test.ts
+++ b/test/mcpregistrystate.test.ts
@@ -1,0 +1,374 @@
+/**
+ * The gate that decides whether `mcp-publisher publish` runs.
+ *
+ * This test exists because of a specific, observed production failure. Only half the release
+ * pipeline had ever been made idempotent: the npm half asks "is this version already published?"
+ * and skips when it is, while both `registry` jobs ran `mcp-publisher publish` unconditionally. On
+ * v1.3.0 the second workflow to arrive re-published what the first had just published:
+ *
+ *     Error: publish failed: server returned status 400: {"title":"Bad Request","status":400,
+ *     "detail":"Failed to publish server","errors":[{"message":"invalid version: cannot publish
+ *     duplicate version"}]}
+ *
+ * — a red run reporting a failure that had in fact already succeeded.
+ *
+ * `scripts/mcp-registry-version-state.mjs` is the missing question, with the same three outcomes as
+ * its npm sibling: `present`, `absent`, and "could not determine". Two properties carry most of the
+ * weight here, and neither is obvious:
+ *
+ *   1. `search` on this endpoint is a SUBSTRING match, so a hit must be confirmed by comparing
+ *      `server.name` AND `server.version` exactly. A test below publishes a decoy.
+ *   2. A 404 is NOT "absent" here — the deliberate opposite of the npm sibling, where 404 is the
+ *      legitimate first-publish answer. This endpoint answers 200 with an empty `servers` array for
+ *      a server it has never heard of, so a 404 means the API moved.
+ *
+ * The registry is injectable — a `fetch` function for the module, a `--response-file` or a
+ * `--registry` pointing at a local `node:http` fixture for the CLI — so none of this touches the
+ * network.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { AddressInfo } from "node:net";
+
+import {
+  ABSENT,
+  PRESENT,
+  UndeterminedError,
+  mcpRegistryVersionState,
+  parseArgs,
+  searchUrl,
+  serverDefaults,
+  stateFromSearch,
+} from "../scripts/mcp-registry-version-state.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = join(ROOT, "scripts", "mcp-registry-version-state.mjs");
+const TMP = mkdtempSync(join(tmpdir(), "mcp-registry-state-"));
+
+const NAME = "io.github.INo-xious/stockbit-mcp";
+
+/** One entry in the shape the registry actually serves, trimmed to what this reads. */
+function entry(name: string, version: string) {
+  return {
+    server: { name, version, description: "…", packages: [{ identifier: "stockbit-mcp", version }] },
+    _meta: { "io.modelcontextprotocol.registry/official": { status: "active", isLatest: true } },
+  };
+}
+
+/** The registry's real answer for "nothing matched" — HTTP 200, empty array. Verified live. */
+const EMPTY = JSON.stringify({ servers: [], metadata: { count: 0 } });
+
+const found = (...entries: ReturnType<typeof entry>[]) =>
+  JSON.stringify({ servers: entries, metadata: { count: entries.length } });
+
+/** `fetch` stand-in: answers once per call from a scripted list, and counts the calls. */
+function fakeFetch(replies: Array<{ status: number; body?: string } | Error>) {
+  const calls: string[] = [];
+  const fn = async (url: string) => {
+    calls.push(String(url));
+    const reply = replies[Math.min(calls.length - 1, replies.length - 1)];
+    if (reply instanceof Error) throw reply;
+    return {
+      status: reply.status,
+      text: async () => reply.body ?? "",
+    } as unknown as Response;
+  };
+  return Object.assign(fn, { calls });
+}
+
+/** No real waiting between retries — the retry policy is under test, not the clock. */
+const noSleep = async () => {};
+
+const ask = (options: Record<string, unknown>) =>
+  mcpRegistryVersionState({ name: NAME, version: "1.3.0", sleep: noSleep, ...options });
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Run the CLI and report exactly what a workflow step would see.
+ *
+ * Asynchronous on purpose. `execFileSync` blocks this process's event loop, which would deadlock
+ * the `node:http` fixture below: the server lives here, so a synchronous child would sit waiting
+ * for a connection this process could not accept until the child's own timeout expired.
+ */
+async function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [SCRIPT, ...args], {
+      encoding: "utf8",
+    });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const e = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: e.code ?? -1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
+/* --------------------------------- the three outcomes --------------------------------- */
+
+test("a version the registry lists is present", async () => {
+  const fetchImpl = fakeFetch([{ status: 200, body: found(entry(NAME, "1.3.0")) }]);
+  assert.equal(await ask({ fetch: fetchImpl }), PRESENT);
+});
+
+test("an empty servers array is absent — the registry's real answer, not an error", async () => {
+  // Verified against the live registry: an unknown version and an unknown server BOTH answer
+  // HTTP 200 with {"servers":[],"metadata":{"count":0}}. This is the first-publish case, and
+  // reading it as anything but "absent" would make every new version unpublishable.
+  const fetchImpl = fakeFetch([{ status: 200, body: EMPTY }]);
+  assert.equal(await ask({ fetch: fetchImpl }), ABSENT);
+});
+
+test("the right server at the wrong version is absent", async () => {
+  const fetchImpl = fakeFetch([{ status: 200, body: found(entry(NAME, "1.2.4")) }]);
+  assert.equal(await ask({ fetch: fetchImpl, version: "1.3.0" }), ABSENT);
+});
+
+/* ------------------- the search is a substring match, so the check is not ------------------- */
+
+test("another publisher's server whose name CONTAINS ours does not count as ours", async () => {
+  // `search` matches substrings. Someone else publishing `io.github.somebody/stockbit-mcp-fork`,
+  // or simply a registry that ranks loosely, must never be able to convince this workflow that OUR
+  // version is already published — that would silently omit a release from the registry forever.
+  const decoy = found(
+    entry("io.github.somebody/stockbit-mcp-fork", "1.3.0"),
+    entry("io.github.other/prefixed-io.github.INo-xious/stockbit-mcp", "1.3.0"),
+  );
+  assert.equal(await ask({ fetch: fakeFetch([{ status: 200, body: decoy }]) }), ABSENT);
+});
+
+test("a hit needs the name AND the version to match, and finds ours among decoys", async () => {
+  const mixed = found(
+    entry("io.github.somebody/stockbit-mcp-fork", "1.3.0"),
+    entry(NAME, "1.2.4"),
+    entry(NAME, "1.3.0"),
+  );
+  assert.equal(await ask({ fetch: fakeFetch([{ status: 200, body: mixed }]) }), PRESENT);
+});
+
+/* ------------------------------- could not determine ------------------------------- */
+
+test("a 404 is undeterminable here, NOT absent", async () => {
+  // The deliberate difference from the npm sibling, where 404 legitimately means "never published".
+  // This endpoint answers 200 for every real query, so a 404 means the API moved — and treating a
+  // moved API as "absent" would be a guess dressed as an answer.
+  const fetchImpl = fakeFetch([{ status: 404, body: "not found" }]);
+  await assert.rejects(ask({ fetch: fetchImpl, retries: 0 }), (error: Error) => {
+    assert.ok(error instanceof UndeterminedError);
+    assert.match(error.message, /HTTP 404/);
+    return true;
+  });
+});
+
+test("HTTP 500 is undeterminable, and is retried first", async () => {
+  const fetchImpl = fakeFetch([{ status: 500, body: "upstream error" }]);
+  await assert.rejects(ask({ fetch: fetchImpl, retries: 2 }), (error: Error) => {
+    assert.ok(error instanceof UndeterminedError);
+    assert.match(error.message, /HTTP 500/, "the human needs the status to act on");
+    return true;
+  });
+  assert.equal(fetchImpl.calls.length, 3, "one attempt plus two retries");
+});
+
+test("a transport failure is reported as a transport failure, not as a verdict", async () => {
+  const fetchImpl = fakeFetch([new Error("getaddrinfo ENOTFOUND registry.modelcontextprotocol.io")]);
+  await assert.rejects(ask({ fetch: fetchImpl, retries: 1 }), (error: Error) => {
+    assert.ok(error instanceof UndeterminedError);
+    assert.match(error.message, /transport failure/);
+    return true;
+  });
+  assert.equal(fetchImpl.calls.length, 2);
+});
+
+test("a malformed body is undeterminable", async () => {
+  const fetchImpl = fakeFetch([{ status: 200, body: '{"servers": [' }]);
+  await assert.rejects(ask({ fetch: fetchImpl }), (error: Error) => {
+    assert.ok(error instanceof UndeterminedError);
+    assert.match(error.message, /valid JSON/);
+    return true;
+  });
+});
+
+test("a 200 body with no servers ARRAY is undeterminable", async () => {
+  // Every real search response has one. A body without it is some other document — an error
+  // envelope, a moved API — and reading "no servers, therefore absent" out of it is the fail-open
+  // this pair of scripts exists to remove.
+  await assert.rejects(ask({ fetch: fakeFetch([{ status: 200, body: '{"error":"gone"}' }]) }), UndeterminedError);
+  await assert.rejects(
+    ask({ fetch: fakeFetch([{ status: 200, body: '{"servers":{"0":{}}}' }]) }),
+    UndeterminedError,
+    "an object is not an array",
+  );
+  await assert.rejects(
+    ask({ fetch: fakeFetch([{ status: 200, body: "[1,2,3]" }]) }),
+    UndeterminedError,
+    "a bare array is not a search response",
+  );
+});
+
+test("junk entries inside a well-formed servers array do not throw, they just do not match", () => {
+  const body = { servers: [null, 42, "x", {}, { server: null }, { server: { name: NAME } }] };
+  assert.equal(stateFromSearch(body, NAME, "1.3.0"), ABSENT);
+});
+
+/* ---------------------------- the name is data, not a URL ---------------------------- */
+
+test("the name and version are percent-encoded into the query, never concatenated", () => {
+  const url = searchUrl(NAME, "1.3.0");
+  assert.match(url, /\/v0\/servers\?search=/);
+  assert.ok(url.includes(encodeURIComponent(NAME)), "the slash in the name must survive as %2F");
+  assert.ok(!url.includes(`search=${NAME}`), "an unencoded slash would change the path");
+
+  // A name or version carrying a `&` must not be able to add a parameter of its own.
+  const hostile = searchUrl("evil&version=1.0.0&x", "9&limit=1");
+  assert.equal(hostile.split("?")[1].split("&").length, 2, "exactly two parameters, always");
+});
+
+test("a trailing slash on the registry does not produce a doubled path", () => {
+  assert.equal(
+    searchUrl("n", "1", "https://example.test//"),
+    searchUrl("n", "1", "https://example.test"),
+  );
+});
+
+/* ------------------------------------- the CLI ------------------------------------- */
+
+test("the CLI prints the word and exits 0 for both real answers", async () => {
+  const present = join(TMP, "present.json");
+  writeFileSync(present, found(entry(NAME, "1.3.0")));
+  const hit = await runCli(["--name", NAME, "--version", "1.3.0", "--response-file", present]);
+  assert.equal(hit.code, 0);
+  assert.equal(hit.stdout.trim(), PRESENT);
+
+  const empty = join(TMP, "empty.json");
+  writeFileSync(empty, EMPTY);
+  const miss = await runCli(["--name", NAME, "--version", "1.3.0", "--response-file", empty]);
+  assert.equal(miss.code, 0);
+  assert.equal(miss.stdout.trim(), ABSENT);
+});
+
+test("the CLI exits 2 and prints NOTHING on stdout when it cannot determine", async () => {
+  // The workflow reads the WORD. If a failure ever printed `absent`, the release pipeline would act
+  // on a guess; if it printed nothing but exited 0, the `case` would fall through to the default.
+  const broken = join(TMP, "broken.json");
+  writeFileSync(broken, "{ not json");
+  const result = await runCli(["--name", NAME, "--version", "1.3.0", "--response-file", broken]);
+  assert.equal(result.code, 2, "2, not 1, so a caller can tell it from a shell error");
+  assert.equal(result.stdout.trim(), "");
+  assert.match(result.stderr, /mcp-registry-version-state:/);
+  assert.doesNotMatch(result.stdout, /absent|present/);
+});
+
+test("an unreadable response file is undeterminable, not absent", async () => {
+  const result = await runCli([
+    "--name", NAME, "--version", "1.3.0",
+    "--response-file", join(TMP, "does-not-exist.json"),
+  ]);
+  assert.equal(result.code, 2);
+  assert.equal(result.stdout.trim(), "");
+});
+
+test("an unknown flag is a hard error rather than a silently ignored argument", async () => {
+  assert.throws(() => parseArgs(["--registry-file", "x"]), UndeterminedError);
+  assert.throws(() => parseArgs(["--name"]), /needs a value/);
+  assert.throws(() => parseArgs(["--retries", "-1"]), /non-negative/);
+  assert.deepEqual(parseArgs(["--name=a", "--version", "1"]), { name: "a", version: "1" });
+
+  const result = await runCli(["--nope"]);
+  assert.equal(result.code, 2, "an unrecognised flag must not be treated as a default lookup");
+});
+
+test("the CLI talks to a real HTTP registry over --registry", async () => {
+  // Proves the network path end to end without the network: the same code the workflow runs, over
+  // a real socket, against a server that answers what the registry answers.
+  let lastPath = "";
+  const server: Server = createServer((req, res) => {
+    lastPath = req.url ?? "";
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(found(entry(NAME, "1.3.0")));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  try {
+    const result = await runCli(["--name", NAME, "--version", "1.3.0", "--registry", `http://127.0.0.1:${port}`]);
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout.trim(), PRESENT);
+    assert.match(lastPath, /^\/v0\/servers\?search=/, "the endpoint the registry actually serves");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("a registry that 500s makes the CLI exit 2, never absent", async () => {
+  const server: Server = createServer((_req, res) => {
+    res.writeHead(500, { "content-type": "text/plain" });
+    res.end("upstream error");
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  try {
+    const result = await runCli([
+      "--name", NAME, "--version", "1.3.0",
+      "--registry", `http://127.0.0.1:${port}`, "--retries", "0",
+    ]);
+    assert.equal(result.code, 2);
+    assert.equal(result.stdout.trim(), "");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+/* --------------------------- the defaults come from server.json --------------------------- */
+
+test("the defaults are server.json's, because that is the document mcp-publisher sends", () => {
+  // Not package.json. `test/distribution.test.ts` pins the two equal, but the workflow must ask
+  // about the version it is actually about to publish, whatever any other file says.
+  const defaults = serverDefaults();
+  assert.equal(typeof defaults.name, "string");
+  assert.ok(defaults.name.length > 0);
+  assert.match(defaults.version, /^\d+\.\d+\.\d+/);
+});
+
+test("an unreadable server.json is undeterminable rather than an empty lookup", () => {
+  assert.throws(() => serverDefaults(join(TMP, "no-such-dir")), UndeterminedError);
+});
+
+/* ------------- the property that matters most: nothing invents an answer ------------- */
+
+test("NO internal failure produces present or absent", async () => {
+  // The sweep. `present` would silently omit a release from the registry; `absent` would send a
+  // publish the registry refuses. Every one of these must be the third outcome instead.
+  const disasters: Array<[string, Record<string, unknown>]> = [
+    ["no name", { name: "" }],
+    ["no version", { version: "" }],
+    ["name is not a string", { name: undefined }],
+    ["version is not a string", { version: 130 as unknown as string }],
+    ["404", { fetch: fakeFetch([{ status: 404 }]), retries: 0 }],
+    ["401", { fetch: fakeFetch([{ status: 401 }]), retries: 0 }],
+    ["truncated JSON", { fetch: fakeFetch([{ status: 200, body: "{" }]), retries: 0 }],
+    ["HTML error page", { fetch: fakeFetch([{ status: 200, body: "<html>502</html>" }]), retries: 0 }],
+    ["null body", { fetch: fakeFetch([{ status: 200, body: "null" }]), retries: 0 }],
+    ["servers missing", { fetch: fakeFetch([{ status: 200, body: "{}" }]), retries: 0 }],
+    ["fetch throws", { fetch: fakeFetch([new Error("boom")]), retries: 0 }],
+    // `null`, not `undefined`: a destructuring default only fills in `undefined`, so this actually
+    // exercises "the injected fetch is unusable" rather than quietly falling back to the global one.
+    ["fetch is not a function", { fetch: null as unknown as typeof fetch, retries: 0 }],
+  ];
+
+  for (const [label, options] of disasters) {
+    await assert.rejects(
+      ask(options),
+      (error: unknown) => {
+        assert.ok(error instanceof Error, `${label}: threw a non-Error`);
+        return true;
+      },
+      `${label} must never resolve to a verdict`,
+    );
+  }
+});


### PR DESCRIPTION

Only half the release pipeline was ever made idempotent. The npm side asks "is this version already published?" and skips when it is; both `registry` jobs ran `mcp-publisher publish` unconditionally, asking nothing.

`npm version <bump> && git push --follow-tags` delivers the commit and the tag in one push with the user's credential, so the GITHUB_TOKEN recursion guard does not apply and BOTH workflows start. The shared concurrency group serialises them: publish.yml gets there first and publishes to npm and to the registry; release.yml then correctly skips the npm publish, still succeeds, and its registry job re-publishes into

    server returned status 400: invalid version: cannot publish duplicate version

— a red run reporting a failure that had in fact already succeeded. Confirmed against the live registry: 1.3.0 was published at 2026-09-01T17:57:22Z and is flagged isLatest.

`scripts/mcp-registry-version-state.mjs` is the missing question, with the same three outcomes as its npm sibling: `present`, `absent`, and "could not determine", the last one never invented as either. Two inversions from that sibling, both deliberate, because the costs are mirror images:

- A 404 is undetermined here, NOT absent. This endpoint answers 200 with an empty `servers` array for a version it does not have and for a server it has never heard of, so a 404 means the API moved.
- The workflows treat undetermined as publish-anyway rather than skip. A wrong `present` silently omits a version from the registry, which is the "silent no-op" publish.yml's own header forbids; a wrong `absent` costs one refused request.

`search` is a substring match, so a hit counts only when the name and the version both compare exactly — otherwise another publisher's similarly-named server could convince this workflow that our release was already out.

The publish step additionally tolerates the duplicate-version error and only that one, which closes the check-then-act race no amount of checking can: the other workflow may publish between this job's query and its command. A non-duplicate 400, a rejected OIDC login and an unreachable registry all still fail red.

The check now runs before the publisher is downloaded, and both that download and the publish are gated on it, so the already-published case costs one HTTP GET and cannot fail on a github.com blip. `server.json` is read rather than package.json or the tag because it is the document mcp-publisher sends, and its version is validated before it reaches $GITHUB_OUTPUT for the reason `decide` spells out: that file is parsed as key=value lines, so a value carrying a newline can define a second key — with `<<` in it, one that survives as the last write and would silently skip the publish.
