### PR TITLE
batch: a news leg, one request per (symbol, window)

### DIFF
--- a/bin/stockbit-batch.ts
+++ b/bin/stockbit-batch.ts
@@ -39,6 +39,7 @@ import { dirname, join, resolve } from "node:path";
 
 import { getBars, MAX_PAGES, ROWS_PER_PAGE } from "../src/core/bars.js";
 import { getBrokerSummary } from "../src/core/marketdetectors.js";
+import { getNews, type StreamItem } from "../src/core/stream.js";
 import { sessionClock } from "../src/core/sessionclock.js";
 import { RATE } from "../src/config.js";
 import { CliParseError, formatUsage, gateCommandLine, isHelpToken, isVersionToken } from "../src/cliargs.js";
@@ -46,7 +47,7 @@ import { VERSION } from "../src/version.js";
 import { BATCH_BIN, BATCH_COMMANDS, BATCH_EPILOGUE } from "../src/batch/cli.js";
 import { plan, planSummary, sessionDates, type BatchKind, type PlanOrder, type WorkItem } from "../src/batch/planner.js";
 import { run, type ProgressEvent } from "../src/batch/runner.js";
-import { verifyBars, verifyBrokerWindow, type WindowVerdict } from "../src/batch/verify.js";
+import { verifyBars, verifyBrokerWindow, verifyNewsWindow, type WindowVerdict } from "../src/batch/verify.js";
 
 const DEFAULT_RATE_MS = 1750;
 const DEFAULT_JITTER_MS = 500;
@@ -100,8 +101,8 @@ function requireDates(): { from: string; to: string } {
 
 function kindFlag(): BatchKind {
   const raw = value("kind");
-  if (raw !== "bars" && raw !== "broker") {
-    throw new Error(`--kind must be bars or broker, got ${JSON.stringify(raw ?? "(absent)")}`);
+  if (raw !== "bars" && raw !== "broker" && raw !== "news") {
+    throw new Error(`--kind must be bars, broker or news, got ${JSON.stringify(raw ?? "(absent)")}`);
   }
   return raw;
 }
@@ -148,17 +149,47 @@ function writeRaw(root: string, item: WorkItem, payload: unknown): void {
   writeFileSync(target, JSON.stringify(payload, null, 1), "utf8");
 }
 
+/**
+ * Pages of news for one symbol over one window, following the stream cursor.
+ *
+ * Capped at NEWS_MAX_PAGES so a symbol with an enormous archive cannot burn a night's request
+ * budget on one work item; `truncated` records that the cap, not the window, ended the walk, and
+ * the verifier refuses to store a truncated set as though it were complete.
+ */
+const NEWS_MAX_PAGES = 10;
+
+async function fetchNews(item: WorkItem): Promise<{ items: StreamItem[]; truncated: boolean; pagesFetched: number }> {
+  const items: StreamItem[] = [];
+  let cursor: string | undefined;
+  let pages = 0;
+  while (pages < NEWS_MAX_PAGES) {
+    const page = await getNews({ symbol: item.symbol, fromDate: item.from, toDate: item.to, lastStreamId: cursor });
+    pages += 1;
+    items.push(...page.items);
+    if (!page.nextCursor || page.items.length === 0) return { items, truncated: false, pagesFetched: pages };
+    cursor = page.nextCursor;
+  }
+  return { items, truncated: true, pagesFetched: pages };
+}
+
 async function fetchItem(item: WorkItem): Promise<unknown> {
-  return item.kind === "bars"
-    ? await getBars({ symbol: item.symbol, from: item.from, to: item.to })
-    : await getBrokerSummary({ symbol: item.symbol, from: item.from, to: item.to });
+  switch (item.kind) {
+    case "bars": return await getBars({ symbol: item.symbol, from: item.from, to: item.to });
+    case "news": return await fetchNews(item);
+    default: return await getBrokerSummary({ symbol: item.symbol, from: item.from, to: item.to });
+  }
 }
 
 function verifyItem(item: WorkItem, payload: unknown): WindowVerdict {
   const window = { from: item.from, to: item.to };
-  return item.kind === "bars"
-    ? verifyBars(window, payload as { bars: { date: string }[]; truncated?: boolean; pagesFetched?: number })
-    : verifyBrokerWindow(window, payload as { from?: string; to?: string });
+  switch (item.kind) {
+    case "bars":
+      return verifyBars(window, payload as { bars: { date: string }[]; truncated?: boolean; pagesFetched?: number });
+    case "news":
+      return verifyNewsWindow(window, payload as { items?: { createdAt?: string }[]; truncated?: boolean; pagesFetched?: number });
+    default:
+      return verifyBrokerWindow(window, payload as { from?: string; to?: string });
+  }
 }
 
 function describeStop(reason: string): string {
@@ -254,6 +285,8 @@ async function fetchCommand(kind: BatchKind): Promise<void> {
  */
 function requestsPerItem(kind: BatchKind, from: string, to: string): number {
   if (kind === "broker") return 1;
+  // Most symbols have a page or less of news in any window; the cap bounds the outliers.
+  if (kind === "news") return Math.min(NEWS_MAX_PAGES, Math.max(1, Math.ceil(sessionDates(from, to).length / 20)));
   const sessions = sessionDates(from, to).length;
   return Math.min(MAX_PAGES, Math.max(1, Math.ceil(sessions / ROWS_PER_PAGE)));
 }
@@ -372,6 +405,7 @@ async function main(): Promise<void> {
     case "plan": return planCommand();
     case "bars": return await fetchCommand("bars");
     case "broker": return await fetchCommand("broker");
+    case "news": return await fetchCommand("news");
     case "probe": return await probeCommand();
     case "status": return statusCommand();
     default:

--- a/src/batch/cli.ts
+++ b/src/batch/cli.ts
@@ -42,7 +42,7 @@ const PACING_FLAGS = {
 export const BATCH_COMMANDS: CommandTable = {
   plan: {
     summary: "show what WOULD be fetched, and how much is already done — makes no requests",
-    valueFlags: { ...SELECTION_VALUE_FLAGS, ...OUTPUT_VALUE_FLAGS, "--kind": { placeholder: "bars|broker", help: "which backfill to plan" }, "--order": PACING_VALUE_FLAGS["--order"] },
+    valueFlags: { ...SELECTION_VALUE_FLAGS, ...OUTPUT_VALUE_FLAGS, "--kind": { placeholder: "bars|broker|news", help: "which backfill to plan" }, "--order": PACING_VALUE_FLAGS["--order"] },
     details: [
       "Always run this first. It is free, and it tells you the request count before you spend it.",
       "",
@@ -74,6 +74,20 @@ export const BATCH_COMMANDS: CommandTable = {
       "the most recent sessions rather than a few symbols covering everything.",
     ],
   },
+  news: {
+    summary: "per-symbol news headlines from the stream, one request per (symbol, window)",
+    flags: PACING_FLAGS,
+    valueFlags: { ...SELECTION_VALUE_FLAGS, ...OUTPUT_VALUE_FLAGS, ...PACING_VALUE_FLAGS },
+    details: [
+      "The stream filtered to its news category: HEADLINES with a publisher link, in Indonesian,",
+      "not article bodies. Stored verbatim under raw/news/<SYMBOL>/<window>.json so that stays",
+      "visible downstream. Follows the cursor up to a page cap; a capped walk is refused rather",
+      "than stored as though it were complete.",
+      "",
+      "Cheap: one page covers most symbols in most windows. The cost that matters is downstream -",
+      "each headline the ML extracts is one LLM call - and that cap lives in idx-ml, not here.",
+    ],
+  },
   probe: {
     summary: "a tiny live check (few symbols, few days) that also records test fixtures",
     valueFlags: { ...SELECTION_VALUE_FLAGS, "--out": OUTPUT_VALUE_FLAGS["--out"] },
@@ -81,7 +95,7 @@ export const BATCH_COMMANDS: CommandTable = {
   },
   status: {
     summary: "how far a backfill has got, read from its checkpoint — makes no requests",
-    valueFlags: { ...SELECTION_VALUE_FLAGS, ...OUTPUT_VALUE_FLAGS, "--kind": { placeholder: "bars|broker", help: "which backfill to report" } },
+    valueFlags: { ...SELECTION_VALUE_FLAGS, ...OUTPUT_VALUE_FLAGS, "--kind": { placeholder: "bars|broker|news", help: "which backfill to report" } },
   },
 };
 

--- a/src/batch/planner.ts
+++ b/src/batch/planner.ts
@@ -25,8 +25,16 @@
 import { normalizeTradeDate } from "../core/dates.js";
 import { normalizeSymbol } from "../symbol.js";
 
-/** The two things this CLI backfills. */
-export type BatchKind = "bars" | "broker";
+/**
+ * The three things this CLI backfills.
+ *
+ * `news` (added 2026-09-05) is the stream filtered to the news category, per symbol. Like bars it
+ * is one work item per symbol per window: the endpoint takes a date range and pages by cursor, so
+ * the request count is symbols x pages, not symbols x sessions. What comes back is HEADLINES with a
+ * publisher link - not article bodies - and the raw payload is stored verbatim so that fact stays
+ * visible downstream rather than being flattened into a field that pretends otherwise.
+ */
+export type BatchKind = "bars" | "broker" | "news";
 
 export type PlanOrder = "recent-first" | "oldest-first" | "symbol-major";
 
@@ -104,10 +112,12 @@ export function plan(opts: PlanOptions): WorkItem[] {
   const order = opts.order ?? "recent-first";
   const items: WorkItem[] = [];
 
-  if (opts.kind === "bars") {
-    // One item per symbol: getBars pages the range internally.
+  if (opts.kind === "bars" || opts.kind === "news") {
+    // One item per symbol: getBars pages the range internally, and the news fetch follows the
+    // stream cursor the same way. A window is the unit of resumption for both.
+    const kind = opts.kind;
     for (const symbol of symbols) {
-      items.push({ kind: "bars", symbol, from, to, key: itemKey("bars", symbol, from, to) });
+      items.push({ kind, symbol, from, to, key: itemKey(kind, symbol, from, to) });
     }
   } else {
     const dates = sessionDates(from, to);

--- a/src/batch/verify.ts
+++ b/src/batch/verify.ts
@@ -122,3 +122,56 @@ export function verifyBars(
 
   return { ok: true };
 }
+
+/**
+ * Check a news page falls inside the requested window.
+ *
+ * The stream endpoint takes `from_date`/`to_date`, and the same silent-200 hazard applies: a
+ * request whose dates were ignored comes back as the newest posts, not the asked-for ones. Each
+ * item's `createdAt` is the evidence, read from the body. An item without one is not a failure of
+ * the window check - the raw row is kept verbatim - but it cannot vouch for the window either, so
+ * a page where NO item carries a date is refused: nothing on it can be filed.
+ *
+ * An EMPTY page is a pass. Most symbols have no news on most days; "nothing was written about
+ * this name in this window" is a real observation the feature side encodes as its own indicator.
+ */
+export function verifyNewsWindow(
+  requested: DateWindow,
+  page: { items?: { createdAt?: string }[]; truncated?: boolean; pagesFetched?: number },
+): WindowVerdict {
+  const items = page.items ?? [];
+  if (items.length === 0) return { ok: true, note: "no news in the window" };
+
+  const dated = items.map((i) => i.createdAt?.slice(0, 10)).filter((d): d is string => !!d);
+  if (dated.length === 0) {
+    return {
+      ok: false,
+      reason: "no item on the page carries a date, so none can be filed under the requested window",
+      observed: `${items.length} item(s), 0 dated`,
+    };
+  }
+
+  const outside = dated.filter((d) => d < requested.from || d > requested.to);
+  if (outside.length) {
+    const newestOutside = [...outside].sort().at(-1);
+    return {
+      ok: false,
+      reason:
+        "the page carries posts outside the requested window - the signature of a request whose " +
+        "dates were ignored and answered with the newest posts instead. Nothing was stored.",
+      observed: `${outside.length} of ${dated.length} dated item(s) outside ${requested.from}..${requested.to}, e.g. ${newestOutside}`,
+    };
+  }
+
+  if (page.truncated) {
+    return {
+      ok: false,
+      reason:
+        "paging hit its ceiling before the window was exhausted, so this page set is incomplete at " +
+        "the old end. Storing it would look like quiet days rather than an incomplete pull.",
+      observed: `pagesFetched=${page.pagesFetched ?? "?"}, oldest ${[...dated].sort()[0]}`,
+    };
+  }
+
+  return { ok: true };
+}

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -27,7 +27,7 @@ import { CliParseError, gateCommandLine } from "../src/cliargs.ts";
 import { BATCH_BIN, BATCH_COMMANDS } from "../src/batch/cli.ts";
 import { itemKey, plan, planSummary, sessionDates, type WorkItem } from "../src/batch/planner.ts";
 import { run, type RunnerDeps } from "../src/batch/runner.ts";
-import { verifyBars, verifyBrokerWindow } from "../src/batch/verify.ts";
+import { verifyBars, verifyBrokerWindow, verifyNewsWindow } from "../src/batch/verify.ts";
 
 const execFileAsync = promisify(execFile);
 after(() => rmSync(STORE, { recursive: true, force: true }));
@@ -40,6 +40,15 @@ test("bars plan one item per symbol — getBars pages the range itself", () => {
   assert.deepEqual(items.map((i) => i.symbol), ["BBCA", "ANTM"]);
   assert.equal(items[0].from, "2026-08-03");
   assert.equal(items[0].to, "2026-08-28");
+});
+
+test("news plan one item per symbol, like bars — the stream pages by cursor", () => {
+  const items = plan({ kind: "news", symbols: ["BBCA", "ANTM"], from: "2026-08-03", to: "2026-08-28" });
+  assert.equal(items.length, 2);
+  assert.deepEqual(items.map((i) => i.kind), ["news", "news"]);
+  assert.equal(items[0].key, itemKey("news", "BBCA", "2026-08-03", "2026-08-28"));
+  // Distinct from the bars key for the same symbol and window, or a checkpoint could confuse them.
+  assert.notEqual(items[0].key, itemKey("bars", "BBCA", "2026-08-03", "2026-08-28"));
 });
 
 test("broker plan one item per symbol AND session — the 120k number", () => {
@@ -265,7 +274,7 @@ test("a success resets the consecutive-failure counter", async () => {
 
 /* ---------------------------------- the --help gate ---------------------------------- */
 
-const SUBCOMMANDS = ["plan", "bars", "broker", "probe", "status"];
+const SUBCOMMANDS = ["plan", "bars", "broker", "news", "probe", "status"];
 
 test("the table covers exactly the commands the bin dispatches", () => {
   assert.deepEqual(Object.keys(BATCH_COMMANDS).sort(), [...SUBCOMMANDS].sort());
@@ -311,4 +320,48 @@ test("`broker --help` returns immediately instead of starting an overnight drip"
   );
   assert.match(stdout, /broker/);
   assert.match(stdout, /--kill-file/);
+});
+
+
+/* ------------------------------------- news verification ------------------------------------- */
+
+test("a news page inside the window passes, and an empty page is a real observation", () => {
+  const window = { from: "2026-08-03", to: "2026-08-07" };
+  const ok = verifyNewsWindow(window, { items: [{ createdAt: "2026-08-04T09:15:00Z" }, { createdAt: "2026-08-07T16:00:00Z" }] });
+  assert.equal(ok.ok, true);
+  const empty = verifyNewsWindow(window, { items: [] });
+  assert.equal(empty.ok, true);
+  assert.match((empty as { note?: string }).note ?? "", /no news/);
+});
+
+test("a news page carrying posts outside the window is refused — the silent-200 signature", () => {
+  // Asked for a week in February, answered with this week: dates were ignored.
+  const verdict = verifyNewsWindow({ from: "2026-02-16", to: "2026-02-20" }, {
+    items: [{ createdAt: "2026-02-18T10:00:00Z" }, { createdAt: "2026-08-28T10:00:00Z" }],
+  });
+  assert.equal(verdict.ok, false);
+  if (!verdict.ok) {
+    assert.match(verdict.reason, /outside the requested window/);
+    assert.match(verdict.observed, /1 of 2/);
+    assert.match(verdict.observed, /2026-08-28/);
+  }
+});
+
+test("a news page where nothing is dated cannot be filed, so it is refused", () => {
+  const verdict = verifyNewsWindow({ from: "2026-08-03", to: "2026-08-07" }, { items: [{}, {}] });
+  assert.equal(verdict.ok, false);
+  if (!verdict.ok) assert.match(verdict.reason, /no item .* carries a date/);
+});
+
+test("a news walk that hit the page cap is refused rather than stored as complete", () => {
+  const verdict = verifyNewsWindow({ from: "2026-01-01", to: "2026-08-28" }, {
+    items: [{ createdAt: "2026-08-01T00:00:00Z" }], truncated: true, pagesFetched: 10,
+  });
+  assert.equal(verdict.ok, false);
+  if (!verdict.ok) assert.match(verdict.reason, /page cap|ceiling/);
+});
+
+test("--kind news is accepted by the CLI gate", () => {
+  assert.doesNotThrow(() => gateCommandLine(BATCH_BIN, BATCH_COMMANDS, ["plan", "--kind", "news", "--from", "2026-08-03", "--to", "2026-08-07"]));
+  assert.ok(BATCH_COMMANDS.news, "the news command must be documented in --help");
 });


### PR DESCRIPTION
## What

A `news` kind for `stockbit-batch`, beside `bars` and `broker`. The idx-ml news extractor has had nothing feeding it since it was built; this is the fetcher, in the one place a scheduled Stockbit call belongs — the batch CLI already owns the session mutex, the pacing, the kill-file and the checkpoint the broker drip runs under.

## Shape

- One work item per symbol per window, like bars: the stream takes `from_date`/`to_date` and pages by cursor. Followed to a cap of 10 pages; a capped walk is marked `truncated` and **refused** by the verifier rather than stored as complete.
- Raw page stored verbatim under `raw/news/<SYMBOL>/<window>.json`. What comes back is **headlines with a publisher link**, in Indonesian — not article bodies — and storing it verbatim keeps that fact visible downstream.
- `verifyNewsWindow` applies the same silent-200 discipline as the other legs: posts outside the requested window are the signature of ignored dates and are refused; a page with nothing dated cannot be filed and is refused; an **empty page passes** — "no news on this name in this window" is a real observation.

## Not in this PR

- No version bump. Lands as code; release is a separate decision.
- The per-day extraction cap (50 LLM calls) lives in idx-ml, where the cost is. Fetching is cheap.

## Verification

`tsc` clean · `test/batch.test.ts` 37/37 · full suite 1648 pass / 0 fail (Windows; ubuntu is the gate).

Note: this branch is cut from `origin/main`, not from the local checkout, because the local `main` carries an unpushed trading-cap commit (`754cc3a`) that conflicts with `src/status.ts` on origin. That commit is left alone for its author to reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
